### PR TITLE
fix: stabilize pointer cursor on links and buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -171,6 +171,16 @@ layer(base);
     cursor: pointer;
   }
 
+  /* Rectangular hit boxes for links; SVG paint holes must not steal hit-testing. */
+  a[href] {
+    display: inline-block;
+  }
+  button svg,
+  [role="button"] svg,
+  a svg {
+    pointer-events: none;
+  }
+
   body {
     @apply bg-surface-container font-figtree text-on-surface antialiased;
   }


### PR DESCRIPTION
## Summary

Give every `href` link a rectangular hit box and ignore pointer events on SVG descendants of buttons and anchors, so Chromium no longer flickers the cursor between pointer and arrow while moving across member booking chrome.

Closes #6

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Host-only `@layer base` change in `src/index.css`. The existing enabled-button `cursor: pointer` rule is unchanged. Utility classes such as `flex`, `block`, and `inline-flex` still override the link display rule, so Top nav logo and My Profile keep their layout. Library Button `transition` is out of scope (tracked on newlife-ui#32).

## Testing

- [x] `pnpm type-check`
- [ ] Manual Chromium: move the pointer slowly across Support footer Contact Support, Top nav items, a primary button with an icon, and login buttons; cursor must stay pointer and must not flicker while still. Confirm flex/block layout links (logo or My Profile) did not jump.

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] This repo has no GitHub Actions CI; merge after local checks and the Chromium pass above

Made with [Cursor](https://cursor.com)