### PR TITLE
chore: add Prettier and .githooks format-staged

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(git rev-parse --show-toplevel </dev/null)"
+exec "${ROOT_DIR}/scripts/format-staged.sh"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist
+build
+coverage
+node_modules
+pnpm-lock.yaml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "trailingComma": "es5",
+  "arrowParens": "always",
+  "printWidth": 120
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,16 +46,23 @@ pnpm dev              # http://localhost:5174 (strictPort — fails if taken)
 pnpm type-check       # tsc -b --noEmit
 pnpm test             # vitest run
 pnpm lint             # eslint .
+pnpm format           # prettier --write .
+pnpm format:check     # prettier --check .
 pnpm build            # tsc -b && vite build
 pnpm build:stg        # --mode staging
 pnpm build:prod       # --mode production
 pnpm preview
 ./scripts/check-branch-name.test.sh
+./scripts/format-staged.test.sh
 ```
 
 ### Branch names
 
 Topic branches: `{type}/{issue-number}-{short-description}` (types: `feat` `fix` `hotfix` `refactor` `perf` `test` `docs` `chore` `build` `ci`). Exceptions: `release/x.y.z`, `spike/{short-description}`, plus `main` / `develop`. Enforced by `.githooks/pre-push` (after install) and `.github/workflows/branch-name.yml`. Emergency: `git push --no-verify`. Consider marking the `Branch name` check required in GitHub branch protection.
+
+### Commit format hook
+
+After `./scripts/install-git-hooks.sh`, `.githooks/pre-commit` formats **staged** files via Prettier, runs `eslint --fix` on staged TS/JS (remaining **errors** fail the commit; warnings do not), and re-stages. Emergency: `git commit --no-verify`. See ADR 0014.
 
 Copy `.env.example` → `.env` (or `.env.local`) before running. Copy `.envrc.example` → `.envrc` (direnv) or export `NODE_AUTH_TOKEN` so pnpm can install `@efcnewlife/newlife-ui`.
 
@@ -194,7 +201,7 @@ Defined but unused by UI today: `MINISTRY.MINISTRY_TYPES`, `MINISTRY.TARGET_AUDI
 | Service           | Owns                                                                       |
 | ----------------- | -------------------------------------------------------------------------- |
 | `authService`     | Login, logout, me, storage, dev login                                      |
-| `ministryService` | `listMine`, `listAssignablePositions`, `listLocales`, `createApplication` |
+| `ministryService` | `listMine`, `listAssignablePositions`, `listLocales`, `createApplication`  |
 | `facilityService` | `getAvailability`, `createBooking`, `listMyBookings` (latter unused by UI) |
 
 Pages should call services, not `httpClient`.
@@ -228,12 +235,7 @@ Authenticated welcome plus a Start Booking action. No question stepper.
 Driven by `?step=` (and `ministry=1|0` after Q1). Step transitions, When validation, and Rooms query building live in `src/utils/startBookingFlow.ts`:
 
 ```ts
-type StartBookingStep =
-  | "ministry_choice"
-  | "select_ministry"
-  | "frequency"
-  | "when"
-  | "space_needed";
+type StartBookingStep = "ministry_choice" | "select_ministry" | "frequency" | "when" | "space_needed";
 ```
 
 Typical progression: ministry yes/no → (ministry name if Yes) → One-time vs Repeated → date and time → Space needed → navigate to `/rooms?...`. Create ministry is a modal on ministry name. The current step is mirrored into the URL with `{ replace: true }`.
@@ -250,16 +252,16 @@ Pure helpers: `timeToMinutes`, `hasContiguousHours` (merges overlapping am/pm sl
 
 ## 8. Pages
 
-| Path                             | Purpose                                                   |
-| -------------------------------- | --------------------------------------------------------- |
-| `login/LoginPage.tsx`                          | Microsoft / optional dev email login, remember me, locale |
-| `home/HomePage.tsx`                            | Welcome + Start Booking                                   |
-| `start-booking/StartBookingPage.tsx`           | Start booking questions                                   |
-| `start-booking/CreateMinistryModal.tsx`        | Create ministry application modal                         |
-| `rooms/RoomFilterPage.tsx`                     | Results, filters, slot select, create booking             |
-| `my-bookings/MyBookingsPage.tsx` | Upcoming/past — **mock data**                             |
-| `my-profile/MyProfilePage.tsx`   | Profile + payment history — **partial mock**              |
-| `contact/ContactPage.tsx`        | Stub                                                      |
+| Path                                    | Purpose                                                   |
+| --------------------------------------- | --------------------------------------------------------- |
+| `login/LoginPage.tsx`                   | Microsoft / optional dev email login, remember me, locale |
+| `home/HomePage.tsx`                     | Welcome + Start Booking                                   |
+| `start-booking/StartBookingPage.tsx`    | Start booking questions                                   |
+| `start-booking/CreateMinistryModal.tsx` | Create ministry application modal                         |
+| `rooms/RoomFilterPage.tsx`              | Results, filters, slot select, create booking             |
+| `my-bookings/MyBookingsPage.tsx`        | Upcoming/past — **mock data**                             |
+| `my-profile/MyProfilePage.tsx`          | Profile + payment history — **partial mock**              |
+| `contact/ContactPage.tsx`               | Stub                                                      |
 
 ---
 
@@ -314,14 +316,14 @@ Use **moment**, not dayjs/date-fns. API date params are `YYYY-MM-DD`. `BookingDa
 
 ## 12. Naming Conventions
 
-| Kind                               | Convention                  | Example                       |
-| ---------------------------------- | --------------------------- | ----------------------------- |
-| Variables, functions (most of app) | camelCase                   | `isAuthenticated`             |
-| Components / page files            | PascalCase                  | `StartBookingPage.tsx`        |
+| Kind                               | Convention                  | Example                          |
+| ---------------------------------- | --------------------------- | -------------------------------- |
+| Variables, functions (most of app) | camelCase                   | `isAuthenticated`                |
+| Components / page files            | PascalCase                  | `StartBookingPage.tsx`           |
 | Page / feature folders             | kebab-case                  | `start-booking/`, `my-bookings/` |
-| Constants, env vars                | UPPER_SNAKE_CASE / `VITE_*` | `VITE_API_BASE_URL`           |
-| Route paths                        | kebab-case                  | `/my-bookings`                |
-| Comments / default copy            | English                     | User strings via i18n         |
+| Constants, env vars                | UPPER_SNAKE_CASE / `VITE_*` | `VITE_API_BASE_URL`              |
+| Route paths                        | kebab-case                  | `/my-bookings`                   |
+| Comments / default copy            | English                     | User strings via i18n            |
 
 **Exception:** `src/i18n/*` and several utils (`bookingMock`, `bookingFormat`) use **snake_case** function names. Match the local file.
 
@@ -368,28 +370,28 @@ Keep Vite **port 5174** / `strictPort` in mind — the admin portal uses 5173.
 
 ## 15. Key Files Index
 
-| File                                     | Why read it                     |
-| ---------------------------------------- | ------------------------------- |
-| `package.json`                           | Scripts, dependencies           |
-| `vite.config.ts`                         | Port 5174, alias, SVGR          |
-| `src/config/env.ts`                      | Env flags                       |
-| `src/App.tsx` / `src/main.tsx`           | Bootstrap                       |
-| `src/routes/index.tsx`                   | All routes                      |
-| `src/context/AuthContext.tsx`            | Auth state                      |
-| `src/auth/msalInstance.ts`               | Entra MSAL                      |
-| `src/api/config/index.ts`                | Endpoint map                    |
-| `src/api/services/httpClient.ts`         | HTTP pipeline                   |
-| `src/api/services/facilityService.ts`    | Availability + create booking   |
-| `src/api/services/ministryService.ts`    | Ministries + applications       |
-| `src/pages/home/HomePage.tsx`                | Authenticated Home              |
-| `src/pages/start-booking/StartBookingPage.tsx` | Start booking questions       |
-| `src/utils/startBookingFlow.ts`              | Step / When / Rooms query seam  |
-| `src/pages/rooms/RoomFilterPage.tsx`         | Search + book                   |
-| `src/types/roomSearch.ts`                | Search criteria                 |
-| `src/utils/roomAvailabilityFilter.ts`    | Client-side availability filter |
-| `src/i18n/index.ts`                      | Locales and namespaces          |
-| `src/index.css`                          | Tokens / theme                  |
-| `docs/design/`                           | Design HTML mocks               |
+| File                                           | Why read it                     |
+| ---------------------------------------------- | ------------------------------- |
+| `package.json`                                 | Scripts, dependencies           |
+| `vite.config.ts`                               | Port 5174, alias, SVGR          |
+| `src/config/env.ts`                            | Env flags                       |
+| `src/App.tsx` / `src/main.tsx`                 | Bootstrap                       |
+| `src/routes/index.tsx`                         | All routes                      |
+| `src/context/AuthContext.tsx`                  | Auth state                      |
+| `src/auth/msalInstance.ts`                     | Entra MSAL                      |
+| `src/api/config/index.ts`                      | Endpoint map                    |
+| `src/api/services/httpClient.ts`               | HTTP pipeline                   |
+| `src/api/services/facilityService.ts`          | Availability + create booking   |
+| `src/api/services/ministryService.ts`          | Ministries + applications       |
+| `src/pages/home/HomePage.tsx`                  | Authenticated Home              |
+| `src/pages/start-booking/StartBookingPage.tsx` | Start booking questions         |
+| `src/utils/startBookingFlow.ts`                | Step / When / Rooms query seam  |
+| `src/pages/rooms/RoomFilterPage.tsx`           | Search + book                   |
+| `src/types/roomSearch.ts`                      | Search criteria                 |
+| `src/utils/roomAvailabilityFilter.ts`          | Client-side availability filter |
+| `src/i18n/index.ts`                            | Locales and namespaces          |
+| `src/index.css`                                | Tokens / theme                  |
+| `docs/design/`                                 | Design HTML mocks               |
 
 ---
 
@@ -397,17 +399,17 @@ Keep Vite **port 5174** / `strictPort` in mind — the admin portal uses 5173.
 
 When given a task, first classify it:
 
-| Task type                        | Start here                                                        |
-| -------------------------------- | ----------------------------------------------------------------- |
-| New authenticated page           | `src/routes/index.tsx` → page folder → `TopNavBar` if nav-visible |
+| Task type                        | Start here                                                            |
+| -------------------------------- | --------------------------------------------------------------------- |
+| New authenticated page           | `src/routes/index.tsx` → page folder → `TopNavBar` if nav-visible     |
 | Start booking question flow      | `startBookingFlow.ts` + `StartBookingPage.tsx` → `RoomFilterPage.tsx` |
-| API contract / new call          | `api/config` → service → `src/types/`                             |
-| Auth / login / remember-me       | `AuthContext`, `authService`, `LoginPage`, `env.ts`               |
-| Availability / create booking    | `facilityService` + `roomAvailabilityFilter`                      |
-| My bookings / profile still fake | Replace `data/mockBookings.ts` / `mockProfile.ts` imports         |
-| i18n string                      | `i18n/locales/*` + `i18n/index.ts` if new namespace               |
-| Visual tokens / styling          | `index.css` + newlife-ui components                               |
-| Design reference                 | `docs/design/*.html`                                              |
+| API contract / new call          | `api/config` → service → `src/types/`                                 |
+| Auth / login / remember-me       | `AuthContext`, `authService`, `LoginPage`, `env.ts`                   |
+| Availability / create booking    | `facilityService` + `roomAvailabilityFilter`                          |
+| My bookings / profile still fake | Replace `data/mockBookings.ts` / `mockProfile.ts` imports             |
+| i18n string                      | `i18n/locales/*` + `i18n/index.ts` if new namespace                   |
+| Visual tokens / styling          | `index.css` + newlife-ui components                                   |
+| Design reference                 | `docs/design/*.html`                                                  |
 
 **Prefer minimal diffs.** Match existing booking/layout patterns before introducing new abstractions. Do not port portal DataPage or backend-driven menus into this app.
 

--- a/docs/adr/0014-prettier-is-the-formatter.md
+++ b/docs/adr/0014-prettier-is-the-formatter.md
@@ -1,0 +1,15 @@
+# Prettier is the formatter
+
+This SPA had no project-owned formatter; ESLint is not a formatter. Prettier is the only frontend formatter for configured file types. Commit-time enforcement uses `.githooks` via `core.hooksPath` (same install story as branch-name `pre-push`), not Husky or lint-staged. Staged script files also run `eslint --fix`; remaining ESLint **errors** fail the commit; warnings do not. `eslint-config-prettier` disables stylistic ESLint rules that conflict with Prettier. Shared Prettier options with sibling Newlife frontends: double quotes, semicolons, `trailingComma: "es5"`, `arrowParens: "always"`, `printWidth: 120`.
+
+## Considered Options
+
+- **Biome** — would duplicate or replace the existing ESLint stack.
+- **ESLint `--fix` alone** — incomplete formatting; leaves style to editors.
+- **Husky + lint-staged** — conflicts with org `.githooks` convention.
+
+## Consequences
+
+- `pnpm run format` / `pnpm run format:check` (scripts ready when CI is added later).
+- Full-tree apply may land in a dedicated follow-up PR when splitting work.
+- Clone once: `./scripts/install-git-hooks.sh`. Emergency: `git commit --no-verify`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
   { ignores: ["dist"] },
@@ -26,4 +27,5 @@ export default tseslint.config(
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
     },
   },
+  eslintConfigPrettier
 );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:watch": "vitest",
     "preview": "vite preview",
     "preview:stg": "vite preview --mode staging",
-    "preview:prod": "vite preview --mode production"
+    "preview:prod": "vite preview --mode production",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@azure/msal-browser": "^4.12.0",
@@ -42,10 +44,12 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.19.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
     "postcss": "^8.5.2",
+    "prettier": "^3.9.6",
     "tailwindcss": "^4.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint:
         specifier: ^9.19.0
         version: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.2.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0))
@@ -90,6 +93,9 @@ importers:
       postcss:
         specifier: ^8.5.2
         version: 8.5.15
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.1
@@ -1143,6 +1149,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
@@ -1173,6 +1185,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1605,6 +1618,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -2881,6 +2899,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
+
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)(supports-color@7.2.0)
@@ -3290,6 +3312,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.9.6: {}
 
   proxy-from-env@2.1.0: {}
 

--- a/scripts/format-staged.sh
+++ b/scripts/format-staged.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Format staged files with Prettier, ESLint --fix on scripts, then re-stage.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+prettier_files=()
+eslint_files=()
+while IFS= read -r path; do
+  [[ -z "${path}" || ! -f "${path}" ]] && continue
+  case "${path}" in
+    *.ts|*.tsx|*.js|*.jsx|*.json|*.css|*.md|*.yml|*.yaml|*.html)
+      prettier_files+=("${path}")
+      ;;
+  esac
+  case "${path}" in
+    *.ts|*.tsx|*.js|*.jsx)
+      eslint_files+=("${path}")
+      ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ "${#prettier_files[@]}" -eq 0 && "${#eslint_files[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ "${#prettier_files[@]}" -gt 0 ]]; then
+  PRETTIER="${ROOT_DIR}/node_modules/.bin/prettier"
+  if [[ ! -x "${PRETTIER}" ]]; then
+    echo "prettier not found at ${PRETTIER}; run pnpm install" >&2
+    exit 1
+  fi
+  "${PRETTIER}" --write -- "${prettier_files[@]}"
+  git add -- "${prettier_files[@]}"
+fi
+
+if [[ "${#eslint_files[@]}" -gt 0 ]]; then
+  ESLINT="${ROOT_DIR}/node_modules/.bin/eslint"
+  if [[ ! -x "${ESLINT}" ]]; then
+    echo "eslint not found at ${ESLINT}; run pnpm install" >&2
+    exit 1
+  fi
+  "${ESLINT}" --fix -- "${eslint_files[@]}"
+  git add -- "${eslint_files[@]}"
+fi

--- a/scripts/format-staged.test.sh
+++ b/scripts/format-staged.test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Black-box tests for scripts/format-staged.sh (Prettier + ESLint)
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMATTER="${ROOT_DIR}/scripts/format-staged.sh"
+FIXTURE_DIR="${ROOT_DIR}/scripts/.format-staged-fixtures"
+pass_count=0
+fail_count=0
+
+cleanup() {
+  if [[ -d "${FIXTURE_DIR}" ]]; then
+    git -C "${ROOT_DIR}" reset HEAD -- "${FIXTURE_DIR}" >/dev/null 2>&1 || true
+    rm -rf "${FIXTURE_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${FIXTURE_DIR}"
+
+assert_true() {
+  local label="$1"
+  shift
+  if "$@"; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${label}"
+  fi
+}
+
+is_staged() {
+  local rel="$1"
+  git -C "${ROOT_DIR}" diff --cached --name-only -- "${rel}" | grep -qx "${rel}"
+}
+
+rel_ugly="scripts/.format-staged-fixtures/ugly.ts"
+cat >"${ROOT_DIR}/${rel_ugly}" <<'TS'
+export const x={a:1,b:2}
+TS
+git -C "${ROOT_DIR}" add -- "${rel_ugly}"
+set +e
+out="$("${FORMATTER}" 2>&1)"
+status=$?
+set -e
+assert_true "format-staged exits 0 for prettier target" test "${status}" -eq 0
+assert_true "prettier added spacing" grep -q 'a: 1' "${ROOT_DIR}/${rel_ugly}"
+assert_true "file still staged" is_staged "${rel_ugly}"
+git -C "${ROOT_DIR}" reset HEAD -- "${rel_ugly}" >/dev/null
+rm -f "${ROOT_DIR}/${rel_ugly}"
+
+# ESLint error that --fix cannot remove (prefer-const is auto-fixable; use a real error)
+# @typescript-eslint recommended includes no-var? Use empty interface with error if set to error - those are warn.
+# Use a syntax that eslint flags as error from recommended: duplicate keys? 
+# `const a: string = 1` might be type error not eslint.
+# Prefer: bare `debugger` is often error in recommended? Actually not in their config.
+# js recommended has no-undef for scripts - but TS files use typed parser.
+# Easiest reliable error: `eslint-disable` won't help. Use `eval`? 
+# typescript-eslint recommended: ban-ts-comment for @ts-ignore? 
+# Let's use: empty file with `throw` and reference undefined with no-undef - for TS files globals.browser means browser globals.
+# From @eslint/js recommended: no-constant-binary-expression? 
+# Simple approach: file with `var unused = 1` is warn only.
+# Use `@ts-expect-error` without description - might be error depending on version.
+# Or: `const x = x;` circular - no-use-before-define?
+
+rel_err="scripts/.format-staged-fixtures/eslint_error.ts"
+cat >"${ROOT_DIR}/${rel_err}" <<'TS'
+export function f() {
+  try {
+    return 1;
+  } finally {
+    return 2;
+  }
+}
+TS
+git -C "${ROOT_DIR}" add -- "${rel_err}"
+set +e
+out="$("${FORMATTER}" 2>&1)"
+status=$?
+set -e
+assert_true "format-staged fails on remaining eslint error" test "${status}" -ne 0
+git -C "${ROOT_DIR}" reset HEAD -- "${rel_err}" >/dev/null
+rm -f "${ROOT_DIR}/${rel_err}"
+
+if [[ "${fail_count}" -gt 0 ]]; then
+  echo "${fail_count} failed, ${pass_count} passed"
+  echo "${out:-}"
+  exit 1
+fi
+
+echo "All ${pass_count} checks passed"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -6,7 +6,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/check-branch-name.sh scripts/check-branch-name.test.sh scripts/install-git-hooks.sh
+chmod +x \
+  .githooks/pre-push \
+  .githooks/pre-commit \
+  scripts/check-branch-name.sh \
+  scripts/check-branch-name.test.sh \
+  scripts/format-staged.sh \
+  scripts/format-staged.test.sh \
+  scripts/install-git-hooks.sh
 
 echo "Installed git hooks (core.hooksPath=.githooks)"
-echo "Emergency bypass: git push --no-verify"
+echo "Emergency bypass: git commit --no-verify / git push --no-verify"


### PR DESCRIPTION
## Summary

Introduce Prettier, `eslint-config-prettier`, and a `.githooks` `pre-commit` hook that formats staged files, runs `eslint --fix` on staged TS/JS (remaining errors fail the commit), and re-stages. ADR 0014 + shell tests. Full-tree apply follows in a stacked PR (no CI workflow in this repo yet).

Part of #11

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [x] Dependency or tooling

## Testing

- [x] `./scripts/format-staged.test.sh`
- [x] `pnpm run type-check`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge (Branch name check if present)