### PR TITLE
feat: add Booking Details page with query draft and create

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,32 +29,48 @@ A booking for one start–end interval on a single calendar day. The date must b
 _Avoid_: one-off as the canonical term, unbounded future dates, overnight or next-day as One-time
 
 **When**:
-The Start booking step for the One-time date and optional start and end. Date is required to continue. Start and end are either both empty or a complete pair; a single bound is invalid. They seed Search Bar Time and do not lock the Timetable.
+The Start booking step for the One-time date and optional start and end. Date is required to continue. Start and end are either both empty or a complete pair; a single bound is invalid. They seed Search Bar Start Time and End Time and do not lock the Timetable.
 _Avoid_: treating start and end as required to Search, treating When as a date range, allowing only start or only end
 
 **Timetable**:
-The post-Search screen: rooms across the top, hours down the side, for one calendar day from 00:00 to 24:00. The route stays `/rooms`.
+The post-Search screen: rooms across the top, hours down the side, for one calendar day from 00:00 to 24:00. The route stays `/rooms`. On entry and after Update search, the grid scrolls to the Booking interval Start Time if that pair is set, otherwise to the earliest non-Closed Slot among visible rooms. Closed gray blocks stay on the axis; scrolling does not crop them.
 _Avoid_: Time Table, Calendar as this screen's name, Rooms as the member-facing screen name, cropping the day to open hours only
 
 **Search Bar**:
-The editable summary of Start booking answers on the Timetable (Ministry, Date, Repetition, Time, # of rooms) plus Update search. Time shows the Booking interval, including a later Timetable pick that differs from When. The Ministry field is hidden unless the person is a Ministry member of at least one active ministry they can book for. When the field shows and the search is Non-ministry, it shows None and they may attach such a ministry. Holding the Owner position does not by itself show this field. Update search applies Search Bar changes (date, ministry, Single/Multiple, Room shortcut, and Time typed in the bar). BOOK still updates Time immediately. Repetition stays One-time in this slice. Update search clears any selection that is not yet confirmed.
-_Avoid_: a read-only recap, treating When start–end as frozen after Search, showing Ministry for Owner position alone, treating pending-only applicants as able to attach a ministry, applying Search Bar fields without Update search, keeping a previous day's rooms after Update search
+The editable summary of Start booking answers on the Timetable, in this order: Ministry, Repetition, Date, Start Time, End Time, # of rooms, plus Update search. Start Time and End Time together are the Booking interval, including a later Timetable pick that differs from When. The Ministry field is hidden unless the person is a Ministry member of at least one active ministry they can book for. When the field shows and the search is Non-ministry, it shows None and they may attach such a ministry. Holding the Owner position does not by itself show this field. Update search applies Search Bar changes (date, ministry, Single/Multiple, Room shortcut, and Start Time / End Time typed in the bar). BOOK and ADD still update Start Time and End Time immediately. Repetition stays One-time in this slice. Update search clears any selection that is not yet confirmed.
+_Avoid_: a read-only recap, treating When start–end as frozen after Search, showing Ministry for Owner position alone, treating pending-only applicants as able to attach a ministry, applying Search Bar fields without Update search, keeping a previous day's rooms after Update search, a single merged Time field as the Search Bar control, Date before Repetition
 
 **Booking Details**:
-The confirm popup opened by Review Booking. Date is that one calendar day. Each Space row has Edit and Remove: Remove drops that room (zero rooms closes Details); Edit closes Details and returns to the Timetable with the current selection. This slice confirms the booking; it does not collect payment.
-_Avoid_: confirm modal as the product name, Confirm & Pay, treating the mock two-day date as the rule, a separate per-room edit mode
+The confirm page after Single Confirm Booking Time, or after Multiple Review Booking. The route is `/booking-details`. Date, Start Time, End Time, rooms, and ministry travel in the query as a draft snapshot, not a lock and not a cart. Each visit (including a pasted URL) reloads availability and Payment Summary from the backend. If any selected room cannot cover the Booking interval, Confirm stays disabled and the member can return to the Timetable. Confirm calls create booking; success goes to Payment. Create failure stays on this page. Date is that one calendar day. Each Space row has Edit and Remove: Remove drops that room (zero rooms returns to the Timetable); Edit returns to the Timetable with the current selection.
+_Avoid_: confirm modal as the product name, treating the query as a reservation, a shopping cart, treating Booking Details as a Timetable popup, treating the mock two-day date as the rule, a separate per-room edit mode, charging a card here
+
+**Payment Summary**:
+The Booking Details aside that shows rate, ministry discount, tax, and total. The backend calculates the money; the client displays it.
+_Avoid_: calculating totals only in the browser, treating this aside as the Interac instructions screen
+
+**Payment**:
+The page after a successful create booking. The route uses the booking id. It shows Canada Interac e-Transfer instructions and a placeholder email, plus the backend total. It does not collect or verify payment. The member continues with Back to Home.
+_Avoid_: Confirm & Pay, a payment processor, treating this page as Booking Details, a second submit that marks the booking paid
 
 **Review Booking**:
-The Timetable CTA that opens Booking Details. Single and Multiple both use it. It is disabled until at least one room is selected. Single keeps at most one room (a later BOOK replaces it). Multiple allows one to three rooms.
-_Avoid_: opening Booking Details from BOOK alone, Review as the name of the popup, requiring two rooms for Multiple
+The Multiple-only Timetable CTA that opens the Booking Details page. The label includes how many rooms are selected. It is disabled until at least one room is added. Multiple allows one to three rooms.
+_Avoid_: Review Booking on Single, Review as the name of Booking Details, requiring two rooms for Multiple, opening Booking Details from ADD alone
 
 **Booking interval**:
-The single start–end all selected rooms share in one One-time booking. It is Search Bar Time and Booking Details Time.
+The single start–end all selected rooms share in one One-time booking. It is Search Bar Start Time and End Time, Confirm Booking Time, and Booking Details Time.
 _Avoid_: per-room times inside one One-time booking, a min–max span with a gap
 
+**Confirm Booking Time**:
+The Single overlay after BOOK. It shows Date (the Search Bar date, not editable) plus Start Time and End Time. The member sets the Booking interval, then continues to the Booking Details page. It always opens on BOOK, including when Start Time and End Time are already filled.
+_Avoid_: Choose time, Booking Details as this overlay, skipping this overlay on Single when Time is already set, opening it from Multiple ADD, letting Date change here
+
 **BOOK**:
-The control on an Available block. It selects that room. With a Booking interval already set, Available means the room covers that whole interval and the interval is at least that room's Template duration; BOOK does not change Time. With no Booking interval yet, BOOK seeds Time from the clicked Slot start for exactly that room's Template duration (click 09:30–10:00 and duration 60 → 09:30–10:30). Clicking a different Available block still changes the shared Booking interval the same way. It does not open Booking Details or create the booking.
-_Avoid_: treating BOOK as Confirm, snapping empty-Time BOOK to the template's start_time chunk
+The control on a Single Available block. It selects that room and always opens Confirm Booking Time. It does not open Booking Details or create the booking.
+_Avoid_: treating BOOK as Confirm, BOOK on Multiple, snapping empty-Time BOOK to the template's start_time chunk without Confirm Booking Time
+
+**ADD**:
+The control on a Multiple Available block. It adds that room to the selection, at most three. With a Booking interval already set, Available means the room covers that whole interval and the interval is at least that room's Template duration; ADD does not change Start Time and End Time. With no Booking interval yet, ADD seeds Start Time and End Time from the clicked Slot start for exactly that room's Template duration. A later ADD on a different span replaces the shared Booking interval and keeps only that room. It does not open Confirm Booking Time, Booking Details, or create the booking.
+_Avoid_: BOOK as the Multiple block control, treating ADD as Confirm
 
 **Slot**:
 The Timetable visual time step: 30 minutes, all day. It is the ruler, not the bookable duration.
@@ -65,7 +81,15 @@ How long one empty-Time BOOK chunk is for that room that day: `slot_duration_min
 _Avoid_: using Template duration as the visual row height, requiring the Booking interval to align to template start_time, rejecting an interval equal to duration
 
 **Available**:
-A Timetable span the member may BOOK. If Time is empty: a free chunk starting at the clicked Slot, length Template duration (and not crossing midnight). If Time is set: the room is free for the whole Booking interval, and that interval is at least the room's Template duration.
+A Timetable span the member may BOOK or ADD. If Start Time and End Time are empty: hover (or a first tap on touch) previews a free chunk on that room only, starting at the Slot, length Template duration (and not crossing midnight); that preview is not a selection and does not paint other rooms. BOOK or ADD then commits that chunk as the Booking interval. If Start Time and End Time are set: the room is free for the whole Booking interval, and that interval is at least the room's Template duration; those rooms show Available without hover.
+
+**Room photo**:
+The picture of a room on the Timetable column header. Opening it shows Image preview. If the room has no picture, the header shows a photo icon, not an image and not a text label.
+_Avoid_: Gallery as the product name, a "No photo" caption, treating a missing picture as an empty gray box with no icon
+
+**Image preview**:
+The overlay that enlarges Room photos, with thumbs and previous/next when there is more than one picture. Close returns to the Timetable.
+_Avoid_: Gallery modal as the product name, a separate route for the photos
 
 **Unavailable**:
 A Timetable block that is inside open hours but cannot be booked because another booking holds it. Not Closed, not Override.

--- a/docs/adr/0005-review-booking-for-single-and-multiple.md
+++ b/docs/adr/0005-review-booking-for-single-and-multiple.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0015
+---
+
 # Single and Multiple both open Booking Details via Review Booking
 
 The single-room Timetable mock has BOOK on an Available block and no Review Booking; the multiple-room mock uses Review Booking (n). We still send both Space needed modes through Review Booking so confirm is one path. BOOK selects a room on the Timetable; it does not submit the booking or open Booking Details.

--- a/docs/adr/0015-single-confirm-booking-time.md
+++ b/docs/adr/0015-single-confirm-booking-time.md
@@ -1,0 +1,3 @@
+# Single uses Confirm Booking Time; Multiple uses Review Booking
+
+ADR 0005 sent both Space needed modes through Review Booking so confirm was one path. We now follow the mocks: Single BOOK always opens Confirm Booking Time then the Booking Details page; Multiple uses ADD and Review Booking (n). One confirm page remains; the Timetable CTA differs so Single is not blocked behind a Review button that the mock does not have.

--- a/docs/adr/0016-booking-details-query-is-a-draft.md
+++ b/docs/adr/0016-booking-details-query-is-a-draft.md
@@ -1,0 +1,3 @@
+# Booking Details is a page; the query is a draft, not a lock
+
+Booking Details is `/booking-details` with date, interval, rooms, and ministry in the query so reload and a pasted URL can reopen the same draft. That snapshot is not a cart and not a hold: every visit refetches availability and the backend quote, and create booking is the reservation. A query is shareable and easy to tamper; sessionStorage would hide the draft from a pasted URL but would not stop two tabs. We accept the query and make the server the source of truth.

--- a/docs/adr/0017-payment-after-create-interac.md
+++ b/docs/adr/0017-payment-after-create-interac.md
@@ -1,0 +1,3 @@
+# Create booking on Confirm, then Payment with Interac copy
+
+Confirm on Booking Details creates the booking and holds the slot. Success goes to Payment keyed by booking id, with Canada Interac e-Transfer instructions and a placeholder email. This slice does not run a processor or mark the booking paid, so we do not label the button Confirm & Pay. Showing Payment before create would leave the slot free while the member reads Interac copy.

--- a/docs/adr/0018-empty-time-available-is-hover-preview.md
+++ b/docs/adr/0018-empty-time-available-is-hover-preview.md
@@ -1,0 +1,3 @@
+# Empty Time Available is hover preview on one room
+
+When Start Time and End Time are empty, the Timetable does not paint Available on every room that could later cover a click. Hover (first tap on touch) previews Template duration on that column only. BOOK or ADD commits the Booking interval; only then do other rooms that cover it show Available. Painting all matching rooms on first click was confusing because it looked like a lock.

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -114,7 +114,14 @@
     "space": "Space",
     "edit": "Edit",
     "remove": "Remove",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "unavailable": "One or more rooms cannot cover this time. Return to the Timetable to change the draft.",
+    "paymentSummary": "Payment Summary",
+    "rate": "Rate",
+    "ministryDiscount": "Ministry discount",
+    "subtotal": "Subtotal",
+    "tax": "HST Tax",
+    "total": "Total"
   },
   "support": {
     "pageTitle": "Support"

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -114,7 +114,14 @@
     "space": "空间",
     "edit": "编辑",
     "remove": "移除",
-    "confirm": "确认"
+    "confirm": "确认",
+    "unavailable": "有房间无法覆盖此时段。请返回时间表修改草稿。",
+    "paymentSummary": "付款摘要",
+    "rate": "费率",
+    "ministryDiscount": "事工折扣",
+    "subtotal": "小计",
+    "tax": "HST 税",
+    "total": "总计"
   },
   "support": {
     "pageTitle": "支持"

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -114,7 +114,14 @@
     "space": "空間",
     "edit": "編輯",
     "remove": "移除",
-    "confirm": "確認"
+    "confirm": "確認",
+    "unavailable": "有房間無法涵蓋此時段。請返回時間表修改草稿。",
+    "paymentSummary": "付款摘要",
+    "rate": "費率",
+    "ministryDiscount": "事工折扣",
+    "subtotal": "小計",
+    "tax": "HST 稅",
+    "total": "總計"
   },
   "support": {
     "pageTitle": "支援"

--- a/src/pages/booking-details/BookingDetailsPage.tsx
+++ b/src/pages/booking-details/BookingDetailsPage.tsx
@@ -1,0 +1,256 @@
+import facilityService from "@/api/services/facilityService";
+import {
+  parseBookingDetailsQuery,
+  parseRoomsSearchQuery,
+  toBookingDetailsSearchParams,
+  toRoomsSearchParams,
+  type BookingDetailsQuery,
+} from "@/utils/startBookingFlow";
+import { isRoomAvailable, type RoomDay } from "@/utils/timetableRules";
+import { Button, cn, Spinner } from "@efcnewlife/newlife-ui";
+import moment from "moment";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Navigate, useNavigate, useSearchParams } from "react-router";
+
+const DASH = "—";
+
+const combineDateAndTime = (date: string, time: string): string => {
+  const clock = time === "24:00" ? "00:00" : time;
+  const day = time === "24:00" ? moment(date, "YYYY-MM-DD").add(1, "day") : moment(date, "YYYY-MM-DD");
+  return moment(`${day.format("YYYY-MM-DD")} ${clock}`, "YYYY-MM-DD HH:mm").toISOString();
+};
+
+const formatClock = (clock: string, locale: string): string => {
+  if (clock === "24:00") {
+    return moment("00:00", "HH:mm").locale(locale).format("h:mm a");
+  }
+  return moment(clock, "HH:mm").locale(locale).format("h:mm a");
+};
+
+const messageFromUnknown = (err: unknown, fallback: string): string => {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  if (typeof err === "object" && err !== null && "message" in err) {
+    const message = (err as { message: unknown }).message;
+    if (typeof message === "string" && message) {
+      return message;
+    }
+  }
+  return fallback;
+};
+
+const selectedRoomsCoverInterval = (rooms: RoomDay[], query: BookingDetailsQuery): boolean => {
+  const interval = { start: query.start, end: query.end };
+  return query.roomIds.every((roomId) => {
+    const room = rooms.find((item) => item.id === roomId);
+    return room != null && isRoomAvailable(room, interval);
+  });
+};
+
+const BookingDetailsPage = () => {
+  const { t, i18n: i18nInstance } = useTranslation("booking");
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryKey = searchParams.toString();
+  const query = useMemo(() => parseBookingDetailsQuery(searchParams), [queryKey, searchParams]);
+  const roomsSearch = useMemo(() => parseRoomsSearchQuery(searchParams), [queryKey, searchParams]);
+
+  const [rooms, setRooms] = useState<RoomDay[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState(false);
+
+  const loadAvailability = useCallback(async () => {
+    if (!query) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const items = await facilityService.getAvailability(query.date, query.ministryId);
+      setRooms(items);
+    } catch (err) {
+      setError(messageFromUnknown(err, t("timetable.loadError")));
+      setRooms([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [query?.date, query?.end, query?.ministryId, query?.start, t]);
+
+  useEffect(() => {
+    void loadAvailability();
+  }, [loadAvailability]);
+
+  const canConfirm = useMemo(() => {
+    if (!query || loading || confirming || created) {
+      return false;
+    }
+    return selectedRoomsCoverInterval(rooms, query);
+  }, [confirming, created, loading, query, rooms]);
+
+  if (!query) {
+    if (!roomsSearch?.date) {
+      return <Navigate replace to="/" />;
+    }
+    return <Navigate replace to={{ pathname: "/rooms", search: toRoomsSearchParams(roomsSearch).toString() }} />;
+  }
+
+  const goToTimetable = (next: BookingDetailsQuery | null) => {
+    if (!next || next.roomIds.length === 0) {
+      navigate({ pathname: "/rooms", search: toRoomsSearchParams(query).toString() });
+      return;
+    }
+    navigate({ pathname: "/rooms", search: toBookingDetailsSearchParams(next).toString() });
+  };
+
+  const handleRemove = (roomId: string) => {
+    const roomIds = query.roomIds.filter((id) => id !== roomId);
+    if (roomIds.length === 0) {
+      goToTimetable(null);
+      return;
+    }
+    setSearchParams(toBookingDetailsSearchParams({ ...query, roomIds }), { replace: true });
+    setCreated(false);
+  };
+
+  const handleConfirm = async () => {
+    if (!canConfirm || !query) {
+      return;
+    }
+    setConfirming(true);
+    setError(null);
+    try {
+      const startAt = combineDateAndTime(query.date, query.start);
+      const endAt = combineDateAndTime(query.date, query.end);
+      await facilityService.createBooking({
+        startAt,
+        endAt,
+        ministryId: query.ministryId || null,
+        rooms: query.roomIds.map((facilityId, index) => ({
+          facilityId,
+          startAt,
+          endAt,
+          sequence: index,
+        })),
+      });
+      setCreated(true);
+    } catch (err) {
+      setError(messageFromUnknown(err, t("timetable.createError")));
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const formattedDate = moment(query.date).locale(i18nInstance.language).format("dddd, MMMM D, YYYY");
+  const formattedInterval = `${formatClock(query.start, i18nInstance.language)} – ${formatClock(query.end, i18nInstance.language)}`;
+  const intervalUncovered = !loading && !selectedRoomsCoverInterval(rooms, query);
+
+  return (
+    <main className="flex flex-1 justify-center bg-surface-container px-4 py-10">
+      <section className="flex w-full max-w-[1200px] flex-col gap-12 rounded-[20px] bg-surface px-6 py-10 sm:flex-row sm:justify-between sm:px-12 sm:pb-12">
+        <div className="min-w-0 max-w-[625px] flex-1">
+          <h1 className="m-0 mb-6 text-[26px] font-semibold leading-none text-booking-primary">
+            {t("bookingDetails.title")}
+          </h1>
+          {error ? (
+            <p className="mb-4 text-sm font-medium text-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {created ? (
+            <p className="mb-4 text-sm font-medium text-booking-green" role="status">
+              {t("timetable.success")}
+            </p>
+          ) : null}
+          {intervalUncovered ? (
+            <p className="mb-4 text-sm font-medium text-error" role="status">
+              {t("bookingDetails.unavailable")}
+            </p>
+          ) : null}
+          {loading ? <Spinner className="mb-4" showText size="sm" text={t("startBooking.loading")} /> : null}
+          <dl>
+            <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
+              <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.date")}</dt>
+              <dd className="m-0 text-xl font-normal leading-[26px]">{formattedDate}</dd>
+            </div>
+            <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
+              <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.repetition")}</dt>
+              <dd className="m-0 text-xl font-normal leading-[26px]">{t("bookingDetails.oneTime")}</dd>
+            </div>
+            <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
+              <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.time")}</dt>
+              <dd className="m-0 text-xl font-normal leading-[26px]">{formattedInterval}</dd>
+            </div>
+            <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
+              <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.space")}</dt>
+              <dd className="m-0 text-xl font-normal leading-[26px]">
+                <div className="flex flex-col gap-4">
+                  {query.roomIds.map((roomId, index) => {
+                    const room = rooms.find((item) => item.id === roomId);
+                    return (
+                      <div
+                        className={cn(
+                          "grid w-full grid-cols-[1fr_auto] items-center gap-4",
+                          index > 0 && "border-t border-gray-300 pt-4"
+                        )}
+                        key={roomId}
+                      >
+                        <span>{room?.name || roomId}</span>
+                        <span className="flex flex-col gap-2">
+                          <Button onClick={() => goToTimetable(query)} size="xs" variant="outline">
+                            {t("bookingDetails.edit")}
+                          </Button>
+                          <Button onClick={() => handleRemove(roomId)} size="xs" variant="outline">
+                            {t("bookingDetails.remove")}
+                          </Button>
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </dd>
+            </div>
+          </dl>
+        </div>
+        <aside className="flex w-full shrink-0 flex-col items-center gap-4 sm:w-[300px]">
+          <h2 className="m-0 text-center text-[26px] font-semibold leading-none text-booking-primary">
+            {t("bookingDetails.paymentSummary")}
+          </h2>
+          <div className="flex w-full flex-col items-center gap-[15px] rounded-[10px] border border-booking-grey bg-booking-bg px-[25px] py-10">
+            <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
+              <span>{t("bookingDetails.rate")}</span>
+              <span>{DASH}</span>
+            </div>
+            <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
+              <span>{t("bookingDetails.ministryDiscount")}</span>
+              <span>{DASH}</span>
+            </div>
+            <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
+            <div className="flex w-[233px] justify-between text-base font-bold leading-5 text-booking-primary">
+              <span>{t("bookingDetails.subtotal")}</span>
+              <span>{DASH}</span>
+            </div>
+            <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
+            <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
+              <span>{t("bookingDetails.tax")}</span>
+              <span>{DASH}</span>
+            </div>
+            <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
+            <div className="flex w-[233px] justify-between text-base font-bold leading-5 text-booking-primary">
+              <span>{t("bookingDetails.total")}</span>
+              <span>{DASH}</span>
+            </div>
+            <Button className="mt-1" disabled={!canConfirm} onClick={() => void handleConfirm()}>
+              {t("bookingDetails.confirm")}
+            </Button>
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+};
+
+export default BookingDetailsPage;

--- a/src/pages/booking-details/BookingDetailsPage.tsx
+++ b/src/pages/booking-details/BookingDetailsPage.tsx
@@ -53,9 +53,8 @@ const BookingDetailsPage = () => {
   const { t, i18n: i18nInstance } = useTranslation("booking");
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const queryKey = searchParams.toString();
-  const query = useMemo(() => parseBookingDetailsQuery(searchParams), [queryKey, searchParams]);
-  const roomsSearch = useMemo(() => parseRoomsSearchQuery(searchParams), [queryKey, searchParams]);
+  const query = useMemo(() => parseBookingDetailsQuery(searchParams), [searchParams]);
+  const roomsSearch = useMemo(() => parseRoomsSearchQuery(searchParams), [searchParams]);
 
   const [rooms, setRooms] = useState<RoomDay[]>([]);
   const [loading, setLoading] = useState(false);
@@ -78,7 +77,7 @@ const BookingDetailsPage = () => {
     } finally {
       setLoading(false);
     }
-  }, [query?.date, query?.end, query?.ministryId, query?.start, t]);
+  }, [query, t]);
 
   useEffect(() => {
     void loadAvailability();

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -3,7 +3,9 @@ import ministryService from "@/api/services/ministryService";
 import type { MinistryItem } from "@/types/ministry";
 import {
   isWhenValid,
+  parseBookingDetailsQuery,
   parseRoomsSearchQuery,
+  toBookingDetailsSearchParams,
   toRoomsSearchParams,
   type RoomsSearchQuery,
   type RoomsSpace,
@@ -17,7 +19,6 @@ import {
   hasNoMatchingResults,
   isBookableCell,
   minutesToClock,
-  removeSelectedRoom,
   SLOT_MINUTES,
   visibleRooms,
   type CapacityBand,
@@ -32,7 +33,6 @@ import {
   Button,
   cn,
   DatePicker,
-  Modal,
   Select,
   Spinner,
   TimePicker,
@@ -44,7 +44,7 @@ import moment from "moment";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdArrowBack, MdArrowForward } from "react-icons/md";
-import { Navigate, useSearchParams } from "react-router";
+import { Navigate, useNavigate, useSearchParams } from "react-router";
 
 const ROOMS_PER_PAGE = 4;
 const CAPACITY_BANDS: CapacityBand[] = ["1-10", "10-25", "25-50", "50+"];
@@ -53,12 +53,6 @@ const TIMETABLE_TRACK = "grid w-full grid-cols-[88px_repeat(4,minmax(0,1fr))] ga
 
 const isActiveMinistry = (item: MinistryItem): boolean => {
   return item.status === "active" && item.isActive !== false;
-};
-
-const combineDateAndTime = (date: string, time: string): string => {
-  const clock = time === "24:00" ? "00:00" : time;
-  const day = time === "24:00" ? moment(date, "YYYY-MM-DD").add(1, "day") : moment(date, "YYYY-MM-DD");
-  return moment(`${day.format("YYYY-MM-DD")} ${clock}`, "YYYY-MM-DD HH:mm").toISOString();
 };
 
 const formatClock = (clock: string, locale: string): string => {
@@ -128,8 +122,10 @@ const CapacityIcon = () => (
 
 const RoomFilterPage = () => {
   const { t, i18n: i18nInstance } = useTranslation("booking");
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const initialQuery = parseRoomsSearchQuery(searchParams);
+  const initialDetails = parseBookingDetailsQuery(searchParams);
 
   const [draftDate, setDraftDate] = useState(initialQuery?.date ?? "");
   const [draftStart, setDraftStart] = useState(initialQuery?.start ?? "");
@@ -142,14 +138,16 @@ const RoomFilterPage = () => {
   const [rooms, setRooms] = useState<RoomDay[]>([]);
   const [bookableMinistries, setBookableMinistries] = useState<MinistryItem[]>([]);
   const [selection, setSelection] = useState<TimetableSelection>({
-    roomIds: [],
-    interval: initialQuery?.start && initialQuery?.end ? { start: initialQuery.start, end: initialQuery.end } : null,
+    roomIds: initialDetails?.roomIds ?? [],
+    interval:
+      initialDetails != null
+        ? { start: initialDetails.start, end: initialDetails.end }
+        : initialQuery?.start && initialQuery?.end
+          ? { start: initialQuery.start, end: initialQuery.end }
+          : null,
   });
-  const [detailsOpen, setDetailsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const appliedQuery = initialQuery;
   const appliedDate = appliedQuery?.date ?? "";
@@ -220,7 +218,6 @@ const RoomFilterPage = () => {
     ...pagedRooms,
     ...Array.from({ length: Math.max(0, ROOMS_PER_PAGE - pagedRooms.length) }, () => null),
   ];
-  const selectedFromAll = rooms.filter((room) => selection.roomIds.includes(room.id));
 
   useEffect(() => {
     setPageIndex(0);
@@ -260,8 +257,6 @@ const RoomFilterPage = () => {
         interval: draftStart && draftEnd ? { start: draftStart, end: draftEnd } : null,
       })
     );
-    setDetailsOpen(false);
-    setSuccessMessage(null);
     setError(null);
   }, [
     appliedRoom,
@@ -305,52 +300,25 @@ const RoomFilterPage = () => {
       setDraftStart(next.interval.start);
       setDraftEnd(next.interval.end);
     }
-    setSuccessMessage(null);
   };
 
-  const handleRemoveRoom = (roomId: string) => {
-    const next = removeSelectedRoom(selection, roomId);
-    setSelection(next);
-    if (next.roomIds.length === 0) {
-      setDetailsOpen(false);
-    }
-  };
-
-  const handleConfirm = async () => {
+  const handleReviewBooking = () => {
     if (!canReviewBooking(selection) || !selection.interval || !appliedDate) {
       return;
     }
-    setConfirming(true);
-    setError(null);
-    try {
-      const startAt = combineDateAndTime(appliedDate, selection.interval.start);
-      const endAt = combineDateAndTime(appliedDate, selection.interval.end);
-      await facilityService.createBooking({
-        startAt,
-        endAt,
-        ministryId: appliedMinistryId || null,
-        rooms: selection.roomIds.map((facilityId, index) => ({
-          facilityId,
-          startAt,
-          endAt,
-          sequence: index,
-        })),
-      });
-      setSuccessMessage(t("timetable.success"));
-      setSelection({ roomIds: [], interval: selection.interval });
-      setDetailsOpen(false);
-      await loadAvailability();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("timetable.createError"));
-    } finally {
-      setConfirming(false);
-    }
+    navigate({
+      pathname: "/booking-details",
+      search: toBookingDetailsSearchParams({
+        date: appliedDate,
+        start: selection.interval.start,
+        end: selection.interval.end,
+        space: appliedSpace,
+        roomIds: selection.roomIds,
+        ...(appliedMinistryId ? { ministryId: appliedMinistryId } : {}),
+        ...(appliedRoom ? { room: appliedRoom } : {}),
+      }).toString(),
+    });
   };
-
-  const formattedDate = moment(appliedDate).locale(i18nInstance.language).format("dddd, MMMM D, YYYY");
-  const formattedInterval = selection.interval
-    ? `${formatClock(selection.interval.start, i18nInstance.language)} – ${formatClock(selection.interval.end, i18nInstance.language)}`
-    : "";
 
   return (
     <main className="mx-auto flex min-h-0 w-full max-w-[1600px] flex-1 flex-col overflow-hidden px-4 py-4 sm:px-6 lg:px-12">
@@ -470,16 +438,6 @@ const RoomFilterPage = () => {
           width="full"
         />
       ) : null}
-      {successMessage ? (
-        <Alert
-          className="mt-4 shrink-0"
-          message={successMessage}
-          size="sm"
-          title={t("timetable.successTitle")}
-          variant="success"
-          width="full"
-        />
-      ) : null}
 
       <section className="mt-4 flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-surface px-4 py-5 xl:px-[42px] xl:pt-7 xl:pb-4">
         <div className="flex shrink-0 items-center justify-between gap-6 bg-surface pb-3">
@@ -531,7 +489,7 @@ const RoomFilterPage = () => {
             <Button
               className="whitespace-nowrap !border-[0.5px] !border-booking-primary !bg-cta !text-on-cta hover:!bg-cta hover:!text-on-cta"
               disabled={!canReviewBooking(selection)}
-              onClick={() => setDetailsOpen(true)}
+              onClick={handleReviewBooking}
               size="xs"
             >
               {appliedSpace === "multiple"
@@ -670,59 +628,6 @@ const RoomFilterPage = () => {
           )}
         </div>
       </section>
-
-      <Modal
-        className="max-w-[960px] p-8"
-        footer={
-          <Button disabled={confirming} onClick={() => void handleConfirm()}>
-            {t("bookingDetails.confirm")}
-          </Button>
-        }
-        isOpen={detailsOpen && canReviewBooking(selection)}
-        onClose={() => setDetailsOpen(false)}
-        title={t("bookingDetails.title")}
-      >
-        <dl>
-          <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
-            <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.date")}</dt>
-            <dd className="m-0 text-xl font-normal leading-[26px]">{formattedDate}</dd>
-          </div>
-          <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
-            <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.repetition")}</dt>
-            <dd className="m-0 text-xl font-normal leading-[26px]">{t("bookingDetails.oneTime")}</dd>
-          </div>
-          <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
-            <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.time")}</dt>
-            <dd className="m-0 text-xl font-normal leading-[26px]">{formattedInterval}</dd>
-          </div>
-          <div className="grid grid-cols-[90px_minmax(0,1fr)] items-start gap-4 border-t border-gray-300 py-4">
-            <dt className="m-0 text-base font-bold leading-[1.125]">{t("bookingDetails.space")}</dt>
-            <dd className="m-0 text-xl font-normal leading-[26px]">
-              <div className="flex flex-col gap-4">
-                {selectedFromAll.map((room, index) => (
-                  <div
-                    className={cn(
-                      "grid w-full grid-cols-[1fr_auto] items-center gap-4",
-                      index > 0 && "border-t border-gray-300 pt-4"
-                    )}
-                    key={room.id}
-                  >
-                    <span>{room.name}</span>
-                    <span className="flex flex-col gap-2">
-                      <Button onClick={() => setDetailsOpen(false)} size="xs" variant="outline">
-                        {t("bookingDetails.edit")}
-                      </Button>
-                      <Button onClick={() => handleRemoveRoom(room.id)} size="xs" variant="outline">
-                        {t("bookingDetails.remove")}
-                      </Button>
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </dd>
-          </div>
-        </dl>
-      </Modal>
     </main>
   );
 };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import AuthenticatedLayout from "@/layout/AuthenticatedLayout";
+import BookingDetailsPage from "@/pages/booking-details/BookingDetailsPage";
 import ContactPage from "@/pages/contact/ContactPage";
 import HomePage from "@/pages/home/HomePage";
 import LoginPage from "@/pages/login/LoginPage";
@@ -28,6 +29,10 @@ export const router = createBrowserRouter([
           {
             path: "/rooms",
             element: <RoomFilterPage />,
+          },
+          {
+            path: "/booking-details",
+            element: <BookingDetailsPage />,
           },
           {
             path: "/my-bookings",

--- a/src/utils/startBookingFlow.test.ts
+++ b/src/utils/startBookingFlow.test.ts
@@ -6,8 +6,10 @@ import {
   isWhenEndAfterStart,
   isWhenValid,
   nextStep,
+  parseBookingDetailsQuery,
   parseRoomsSearchQuery,
   previousStep,
+  toBookingDetailsSearchParams,
   toRoomsSearchParams,
   type StartBookingAnswers,
 } from "./startBookingFlow";
@@ -72,7 +74,9 @@ describe("nextStep", () => {
 
   it("goes from a date-only When to Space needed", () => {
     const now = new Date("2026-08-13T12:00:00");
-    expect(nextStep("when", answers({ when: { date: "2026-08-20", start: null, end: null } }), now)).toBe("space_needed");
+    expect(nextStep("when", answers({ when: { date: "2026-08-20", start: null, end: null } }), now)).toBe(
+      "space_needed"
+    );
   });
 
   it("goes from a valid When to Space needed", () => {
@@ -271,7 +275,9 @@ describe("buildRoomsSearchQuery", () => {
   });
 
   it("sends optional start and end when When is date-only", () => {
-    expect(buildRoomsSearchQuery(answers({ when: { date: "2026-09-01", start: null, end: null }, space: "single" }))).toEqual({
+    expect(
+      buildRoomsSearchQuery(answers({ when: { date: "2026-09-01", start: null, end: null }, space: "single" }))
+    ).toEqual({
       date: "2026-09-01",
       space: "single",
     });
@@ -309,5 +315,57 @@ describe("parseRoomsSearchQuery", () => {
       date: "2026-09-01",
       space: "single",
     });
+  });
+});
+
+describe("parseBookingDetailsQuery", () => {
+  it("returns null when date, interval, or rooms are missing", () => {
+    expect(parseBookingDetailsQuery(new URLSearchParams())).toBe(null);
+    expect(parseBookingDetailsQuery(new URLSearchParams("date=2026-09-01&start=09:00&end=11:00&space=single"))).toBe(
+      null
+    );
+    expect(parseBookingDetailsQuery(new URLSearchParams("date=2026-09-01&rooms=room-a&space=single"))).toBe(null);
+    expect(parseBookingDetailsQuery(new URLSearchParams("start=09:00&end=11:00&rooms=room-a&space=single"))).toBe(null);
+  });
+
+  it("reads a draft snapshot of date, interval, rooms, space, and ministry", () => {
+    const params = new URLSearchParams(
+      "date=2026-09-01&start=09:00&end=11:00&space=multiple&rooms=room-a,room-b&ministryId=m-1&room=gym"
+    );
+    expect(parseBookingDetailsQuery(params)).toEqual({
+      date: "2026-09-01",
+      start: "09:00",
+      end: "11:00",
+      space: "multiple",
+      roomIds: ["room-a", "room-b"],
+      ministryId: "m-1",
+      room: "gym",
+    });
+  });
+
+  it("keeps at most three room ids and drops blanks", () => {
+    expect(
+      parseBookingDetailsQuery(new URLSearchParams("date=2026-09-01&start=09:00&end=11:00&space=single&rooms=a,,b,c,d"))
+    ).toEqual({
+      date: "2026-09-01",
+      start: "09:00",
+      end: "11:00",
+      space: "single",
+      roomIds: ["a", "b", "c"],
+    });
+  });
+});
+
+describe("toBookingDetailsSearchParams", () => {
+  it("round-trips a draft snapshot", () => {
+    const query = {
+      date: "2026-09-01",
+      start: "10:00",
+      end: "11:30",
+      space: "single" as const,
+      roomIds: ["room-a"],
+      ministryId: "m-1",
+    };
+    expect(parseBookingDetailsQuery(toBookingDetailsSearchParams(query))).toEqual(query);
   });
 });

--- a/src/utils/startBookingFlow.ts
+++ b/src/utils/startBookingFlow.ts
@@ -236,3 +236,46 @@ export const toRoomsSearchParams = (query: RoomsSearchQuery): URLSearchParams =>
   }
   return params;
 };
+
+export interface BookingDetailsQuery extends RoomsSearchQuery {
+  start: string;
+  end: string;
+  roomIds: string[];
+}
+
+const MAX_BOOKING_DETAIL_ROOMS = 3;
+
+const parseRoomIdsParam = (params: URLSearchParams): string[] => {
+  const raw = params.get("rooms");
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .slice(0, MAX_BOOKING_DETAIL_ROOMS);
+};
+
+export const parseBookingDetailsQuery = (params: URLSearchParams): BookingDetailsQuery | null => {
+  const search = parseRoomsSearchQuery(params);
+  if (!search?.start || !search.end) {
+    return null;
+  }
+  const roomIds = parseRoomIdsParam(params);
+  if (roomIds.length === 0) {
+    return null;
+  }
+  return {
+    ...search,
+    start: search.start,
+    end: search.end,
+    roomIds,
+  };
+};
+
+export const toBookingDetailsSearchParams = (query: BookingDetailsQuery): URLSearchParams => {
+  const params = toRoomsSearchParams(query);
+  params.set("rooms", query.roomIds.join(","));
+  return params;
+};

--- a/src/utils/visitAccess.test.ts
+++ b/src/utils/visitAccess.test.ts
@@ -55,7 +55,7 @@ describe("visitAccess", () => {
     ).toBe("allow");
   });
 
-  it.each(["/", "/start-booking", "/contact", "/my-bookings", "/rooms", "/my-profile"])(
+  it.each(["/", "/start-booking", "/contact", "/my-bookings", "/rooms", "/booking-details", "/my-profile"])(
     "allows an authenticated member to open %s",
     (pathname) => {
       expect(

--- a/src/utils/visitAccess.ts
+++ b/src/utils/visitAccess.ts
@@ -8,6 +8,7 @@ const KNOWN_MEMBER_PATHS = new Set([
   "/",
   "/start-booking",
   "/rooms",
+  "/booking-details",
   "/my-bookings",
   "/my-profile",
   SUPPORT_PATH,


### PR DESCRIPTION
## Summary

Booking Details is now a `/booking-details` page. Date, interval, rooms, space, and ministry travel in the query as a draft; each visit refetches availability. Confirm creates the booking (success stays on the page until Payment exists). Review Booking on the Timetable navigates here.

Closes #20

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Invalid or incomplete query redirects to the Timetable, or Home if date is missing. Confirm stays disabled when any selected room cannot cover the Booking interval. Payment Summary uses em dashes until the quote ticket. Single Confirm Booking Time overlay is out of this slice; Timetable still uses Review Booking.

## Testing

- [x] `pnpm test`
- [x] `pnpm type-check`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)