### PR TITLE
feat: preview empty-Time Available on hover or first tap

### DIFF
--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -16,6 +16,8 @@ import {
   clearUnconfirmedSelection,
   clockToMinutes,
   displayBlocks,
+  emptyTimeBookInterval,
+  emptyTimePointerAction,
   hasNoMatchingResults,
   isBookableCell,
   minutesToClock,
@@ -23,6 +25,8 @@ import {
   visibleRooms,
   type CapacityBand,
   type CellState,
+  type HoverPreview,
+  type PointerKind,
   type RoomDay,
   type TimetableSelection,
   type TimetableView,
@@ -148,6 +152,7 @@ const RoomFilterPage = () => {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hover, setHover] = useState<HoverPreview | null>(null);
 
   const appliedQuery = initialQuery;
   const appliedDate = appliedQuery?.date ?? "";
@@ -251,6 +256,7 @@ const RoomFilterPage = () => {
       next.room = appliedRoom;
     }
     setSearchParams(toRoomsSearchParams(next), { replace: true });
+    setHover(null);
     setSelection(
       clearUnconfirmedSelection({
         roomIds: selection.roomIds,
@@ -295,11 +301,39 @@ const RoomFilterPage = () => {
       return;
     }
     const next = bookRoom(selection, room, cellStart, appliedSpace);
+    setHover(null);
     setSelection(next);
     if (next.interval) {
       setDraftStart(next.interval.start);
       setDraftEnd(next.interval.end);
     }
+  };
+
+  const pointerKindFromEvent = (event: { pointerType: string }): PointerKind => {
+    return event.pointerType === "mouse" ? "mouse" : "touch";
+  };
+
+  const handleCellPointerEnter = (room: RoomDay, cellStart: string, event: { pointerType: string }) => {
+    if (event.pointerType !== "mouse" || selection.interval || emptyTimeBookInterval(room, cellStart) == null) {
+      return;
+    }
+    setHover({ roomId: room.id, cellStart });
+  };
+
+  const handleCellPointerUp = (room: RoomDay, cellStart: string, event: { pointerType: string }) => {
+    if (pointerKindFromEvent(event) === "mouse") {
+      return;
+    }
+    if (!isBookableCell(room, cellStart, selection.interval)) {
+      return;
+    }
+    const target = { roomId: room.id, cellStart };
+    const action = emptyTimePointerAction(selection.interval, "touch", hover, target);
+    if (action === "preview") {
+      setHover(target);
+      return;
+    }
+    handleBook(room, cellStart);
   };
 
   const handleReviewBooking = () => {
@@ -554,7 +588,15 @@ const RoomFilterPage = () => {
 
           {noMatching ? null : (
             <div className="relative min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain pt-4">
-              <div aria-label={t("timetable.searchBar")} className={cn(TIMETABLE_TRACK, "grid-rows-[repeat(48,40px)]")}>
+              <div
+                aria-label={t("timetable.searchBar")}
+                className={cn(TIMETABLE_TRACK, "grid-rows-[repeat(48,40px)]")}
+                onPointerLeave={(event) => {
+                  if (event.pointerType === "mouse") {
+                    setHover(null);
+                  }
+                }}
+              >
                 <div aria-hidden className="pointer-events-none col-start-1 row-span-full bg-surface" />
                 {hourLabels.map((label, hour) => (
                   <div
@@ -580,6 +622,21 @@ const RoomFilterPage = () => {
                         )}
                         disabled={!bookable}
                         key={`${room?.id ?? `empty-${roomIndex}`}-${cellIndex}`}
+                        onPointerEnter={(event) => {
+                          if (room && cell) {
+                            handleCellPointerEnter(room, cell.start, event);
+                          }
+                        }}
+                        onPointerDown={(event) => {
+                          if (pointerKindFromEvent(event) !== "mouse") {
+                            event.preventDefault();
+                          }
+                        }}
+                        onPointerUp={(event) => {
+                          if (room && cell) {
+                            handleCellPointerUp(room, cell.start, event);
+                          }
+                        }}
                         onClick={() => {
                           if (room && cell) {
                             handleBook(room, cell.start);
@@ -592,7 +649,7 @@ const RoomFilterPage = () => {
                   })
                 )}
                 {pagedRooms.map((room, roomIndex) =>
-                  displayBlocks(room, selection.interval).map((block) => {
+                  displayBlocks(room, selection.interval, hover).map((block) => {
                     const startRow = clockToMinutes(block.start) / SLOT_MINUTES + 1;
                     const endRow = clockToMinutes(block.end) / SLOT_MINUTES + 1;
                     const bookableStart =

--- a/src/utils/timetableRules.test.ts
+++ b/src/utils/timetableRules.test.ts
@@ -7,6 +7,7 @@ import {
   clearUnconfirmedSelection,
   displayBlocks,
   emptyTimeBookInterval,
+  emptyTimePointerAction,
   hasNoMatchingResults,
   isRoomAvailable,
   matchesCapacityBand,
@@ -222,7 +223,10 @@ describe("clearUnconfirmedSelection", () => {
 
 describe("removeSelectedRoom", () => {
   it("drops that room and keeps the rest", () => {
-    const selected: TimetableSelection = { roomIds: ["gym-id", "chapel-id"], interval: { start: "10:00", end: "11:00" } };
+    const selected: TimetableSelection = {
+      roomIds: ["gym-id", "chapel-id"],
+      interval: { start: "10:00", end: "11:00" },
+    };
     expect(removeSelectedRoom(selected, "gym-id").roomIds).toEqual(["chapel-id"]);
   });
 });
@@ -233,14 +237,67 @@ describe("displayBlocks", () => {
     expect(blocks.some((block) => block.state === "available")).toBe(false);
   });
 
+  it("paints a Template-duration Available preview only on the hovered room", () => {
+    const hover = { roomId: "gym-id", cellStart: "09:30" };
+    expect(displayBlocks(gym(), null, hover).filter((block) => block.state === "available")).toEqual([
+      { start: "09:30", end: "10:30", state: "available" },
+    ]);
+    expect(displayBlocks(chapel(), null, hover).some((block) => block.state === "available")).toBe(false);
+  });
+
+  it("does not preview Available that would cross midnight", () => {
+    const late = gym({
+      templates: [{ start: "22:00", end: "24:00", slotDurationMinutes: 60 }],
+      cells: gymCells({
+        "22:00": "available",
+        "22:30": "available",
+        "23:00": "available",
+        "23:30": "available",
+      }),
+    });
+    const blocks = displayBlocks(late, null, { roomId: "gym-id", cellStart: "23:30" });
+    expect(blocks.some((block) => block.state === "available")).toBe(false);
+  });
+
   it("paints Available only on the Booking interval", () => {
     const blocks = displayBlocks(gym(), { start: "10:00", end: "11:30" });
-    expect(blocks.filter((block) => block.state === "available")).toEqual([{ start: "10:00", end: "11:30", state: "available" }]);
+    expect(blocks.filter((block) => block.state === "available")).toEqual([
+      { start: "10:00", end: "11:30", state: "available" },
+    ]);
+  });
+
+  it("paints committed Available without hover on rooms that cover the interval", () => {
+    const interval = { start: "10:00", end: "11:00" };
+    expect(displayBlocks(gym(), interval).filter((block) => block.state === "available")).toEqual([
+      { start: "10:00", end: "11:00", state: "available" },
+    ]);
+    expect(displayBlocks(chapel(), interval).filter((block) => block.state === "available")).toEqual([
+      { start: "10:00", end: "11:00", state: "available" },
+    ]);
   });
 
   it("keeps Unavailable blocks when Time is set", () => {
     const occupied = gym({ cells: gymCells({ "13:00": "unavailable", "13:30": "unavailable" }) });
     const blocks = displayBlocks(occupied, { start: "10:00", end: "11:00" });
     expect(blocks).toContainEqual({ start: "13:00", end: "14:00", state: "unavailable" });
+  });
+});
+
+describe("emptyTimePointerAction", () => {
+  it("commits a mouse click without a prior preview", () => {
+    expect(emptyTimePointerAction(null, "mouse", null, { roomId: "gym-id", cellStart: "09:30" })).toBe("commit");
+  });
+
+  it("previews the first touch on a cell and commits the second tap on the same cell", () => {
+    const gymSlot = { roomId: "gym-id", cellStart: "09:30" };
+    expect(emptyTimePointerAction(null, "touch", null, gymSlot)).toBe("preview");
+    expect(emptyTimePointerAction(null, "touch", gymSlot, gymSlot)).toBe("commit");
+    expect(emptyTimePointerAction(null, "touch", gymSlot, { roomId: "gym-id", cellStart: "10:00" })).toBe("preview");
+  });
+
+  it("commits when Time is already set", () => {
+    expect(
+      emptyTimePointerAction({ start: "10:00", end: "11:00" }, "touch", null, { roomId: "gym-id", cellStart: "10:00" })
+    ).toBe("commit");
   });
 });

--- a/src/utils/timetableRules.ts
+++ b/src/utils/timetableRules.ts
@@ -134,7 +134,12 @@ export const isBookableCell = (room: RoomDay, cellStart: string, interval: Booki
   return emptyTimeBookInterval(room, cellStart) != null;
 };
 
-export const bookRoom = (selection: TimetableSelection, room: RoomDay, cellStart: string, space: RoomsSpace): TimetableSelection => {
+export const bookRoom = (
+  selection: TimetableSelection,
+  room: RoomDay,
+  cellStart: string,
+  space: RoomsSpace
+): TimetableSelection => {
   const current = selection.interval;
   if (current && isCellInInterval(cellStart, current) && isRoomAvailable(room, current)) {
     if (space === "single") {
@@ -195,7 +200,7 @@ export const visibleRooms = (
   view: TimetableView,
   interval: BookingInterval | null,
   band: CapacityBand | null,
-  shortcut: RoomShortcutCode | undefined,
+  shortcut: RoomShortcutCode | undefined
 ): RoomDay[] => {
   const filtered = rooms.filter((room) => matchesCapacityBand(room, band) && matchesRoomShortcut(room, shortcut));
   if (view === "all") {
@@ -209,7 +214,7 @@ export const hasNoMatchingResults = (
   view: TimetableView,
   interval: BookingInterval | null,
   band: CapacityBand | null,
-  shortcut: RoomShortcutCode | undefined,
+  shortcut: RoomShortcutCode | undefined
 ): boolean => {
   return view === "available" && visibleRooms(rooms, view, interval, band, shortcut).length === 0;
 };
@@ -220,6 +225,28 @@ export const clearUnconfirmedSelection = (selection: TimetableSelection): Timeta
 
 export const removeSelectedRoom = (selection: TimetableSelection, roomId: string): TimetableSelection => {
   return { ...selection, roomIds: selection.roomIds.filter((id) => id !== roomId) };
+};
+
+export interface HoverPreview {
+  roomId: string;
+  cellStart: string;
+}
+
+export type PointerKind = "mouse" | "touch";
+
+export const emptyTimePointerAction = (
+  interval: BookingInterval | null,
+  pointerKind: PointerKind,
+  hover: HoverPreview | null,
+  target: HoverPreview
+): "preview" | "commit" => {
+  if (interval != null || pointerKind === "mouse") {
+    return "commit";
+  }
+  if (hover?.roomId === target.roomId && hover.cellStart === target.cellStart) {
+    return "commit";
+  }
+  return "preview";
 };
 
 export interface CellBlock extends TimeRange {
@@ -239,10 +266,22 @@ export const contiguousBlocks = (room: RoomDay): CellBlock[] => {
   return blocks;
 };
 
-export const displayBlocks = (room: RoomDay, interval: BookingInterval | null): CellBlock[] => {
-  const occupied = contiguousBlocks(room).filter((block) => block.state === "unavailable" || block.state === "override");
+export const displayBlocks = (
+  room: RoomDay,
+  interval: BookingInterval | null,
+  hover: HoverPreview | null = null
+): CellBlock[] => {
+  const occupied = contiguousBlocks(room).filter(
+    (block) => block.state === "unavailable" || block.state === "override"
+  );
   if (interval && isRoomAvailable(room, interval)) {
     return [...occupied, { start: interval.start, end: interval.end, state: "available" }];
+  }
+  if (!interval && hover?.roomId === room.id) {
+    const preview = emptyTimeBookInterval(room, hover.cellStart);
+    if (preview) {
+      return [...occupied, { start: preview.start, end: preview.end, state: "available" }];
+    }
   }
   return occupied;
 };


### PR DESCRIPTION
## Summary

When Start Time and End Time are empty, the Timetable no longer paints Available on every room. Hover (or a first tap on touch) previews a Template-duration chunk on that column only; BOOK/ADD (or a mouse/keyboard click) commits the shared Booking interval, after which rooms that cover it show Available without hover.

Closes #17

## Type of change

- [x] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Painting and first-vs-second tap live in `timetableRules` (`displayBlocks`, `emptyTimePointerAction`). The Timetable page only wires pointer enter/leave/up and click so keyboard activation still uses `onClick`.

## Testing

- [x] `pnpm test`
- [x] `pnpm run type-check`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)