### PR TITLE
feat: show Room photos and Image preview on the Timetable

### DIFF
--- a/src/components/booking/ImagePreview.tsx
+++ b/src/components/booking/ImagePreview.tsx
@@ -1,0 +1,109 @@
+import { canOpenImagePreview, nextPreviewIndex, previousPreviewIndex } from "@/utils/imagePreview";
+import { Button, cn } from "@efcnewlife/newlife-ui";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { MdArrowBack, MdArrowForward, MdClose } from "react-icons/md";
+
+interface ImagePreviewProps {
+  photoUrls: string[];
+  onClose: () => void;
+}
+
+const ImagePreview = ({ photoUrls, onClose }: ImagePreviewProps) => {
+  const { t } = useTranslation("booking");
+  const [index, setIndex] = useState(0);
+  const showNav = photoUrls.length > 1;
+  const currentUrl = photoUrls[index];
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+      if (event.key === "ArrowLeft") {
+        setIndex((current) => previousPreviewIndex(current, photoUrls.length));
+      }
+      if (event.key === "ArrowRight") {
+        setIndex((current) => nextPreviewIndex(current, photoUrls.length));
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [onClose, photoUrls.length]);
+
+  if (!canOpenImagePreview(photoUrls) || !currentUrl) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-booking-primary/40 px-4 py-8"
+      onClick={onClose}
+      role="presentation"
+    >
+      <section
+        aria-label={t("imagePreview.dialog")}
+        className="relative w-full max-w-[720px] overflow-hidden rounded-sm bg-surface shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <div className="relative bg-booking-grey">
+          <img alt="" className="mx-auto max-h-[70vh] w-full object-contain" src={currentUrl} />
+          <button
+            aria-label={t("imagePreview.close")}
+            className="absolute right-3 top-3 flex size-[30px] items-center justify-center text-white"
+            onClick={onClose}
+            type="button"
+          >
+            <MdClose size={30} />
+          </button>
+        </div>
+        {showNav ? (
+          <div className="flex items-center justify-between gap-4 bg-booking-primary px-4 py-3">
+            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+              {photoUrls.map((url, thumbIndex) => (
+                <button
+                  aria-current={thumbIndex === index ? "true" : undefined}
+                  aria-label={t("imagePreview.thumb", { index: thumbIndex + 1 })}
+                  className={cn(
+                    "size-10 shrink-0 overflow-hidden rounded-sm border-2",
+                    thumbIndex === index ? "border-white" : "border-transparent opacity-70"
+                  )}
+                  key={`${url}-${thumbIndex}`}
+                  onClick={() => setIndex(thumbIndex)}
+                  type="button"
+                >
+                  <img alt="" className="size-full object-cover" src={url} />
+                </button>
+              ))}
+            </div>
+            <div className="flex shrink-0 gap-3">
+              <Button
+                className="min-w-10"
+                onClick={() => setIndex((current) => previousPreviewIndex(current, photoUrls.length))}
+                size="xs"
+                startIcon={<MdArrowBack size={16} />}
+              >
+                <span className="sr-only">{t("imagePreview.previous")}</span>
+              </Button>
+              <Button
+                className="min-w-10"
+                onClick={() => setIndex((current) => nextPreviewIndex(current, photoUrls.length))}
+                size="xs"
+                startIcon={<MdArrowForward size={16} />}
+              >
+                <span className="sr-only">{t("imagePreview.next")}</span>
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -132,6 +132,14 @@
     "next": "Next image",
     "zoom": "View room photos"
   },
+  "imagePreview": {
+    "dialog": "Room image preview",
+    "close": "Close preview",
+    "previous": "Previous image",
+    "next": "Next image",
+    "zoom": "Preview room image",
+    "thumb": "Photo {{index}}"
+  },
   "profile": {
     "myProfile": "My Profile",
     "signOut": "Sign out",

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -132,6 +132,14 @@
     "next": "下一张",
     "zoom": "查看场地照片"
   },
+  "imagePreview": {
+    "dialog": "场地照片预览",
+    "close": "关闭预览",
+    "previous": "上一张",
+    "next": "下一张",
+    "zoom": "预览场地照片",
+    "thumb": "照片 {{index}}"
+  },
   "profile": {
     "myProfile": "我的个人资料",
     "signOut": "退出登录",

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -132,6 +132,14 @@
     "next": "下一張",
     "zoom": "查看場地照片"
   },
+  "imagePreview": {
+    "dialog": "場地照片預覽",
+    "close": "關閉預覽",
+    "previous": "上一張",
+    "next": "下一張",
+    "zoom": "預覽場地照片",
+    "thumb": "照片 {{index}}"
+  },
   "profile": {
     "myProfile": "我的個人資料",
     "signOut": "登出",

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -1,6 +1,6 @@
 import facilityService from "@/api/services/facilityService";
-import ImagePreview from "@/components/booking/ImagePreview";
 import ministryService from "@/api/services/ministryService";
+import ImagePreview from "@/components/booking/ImagePreview";
 import type { MinistryItem } from "@/types/ministry";
 import { canOpenImagePreview } from "@/utils/imagePreview";
 import {
@@ -617,7 +617,7 @@ const RoomFilterPage = () => {
                             type="button"
                           >
                             <img alt="" className="size-full object-cover" src={room.photoUrls[0]} />
-                            <span className="pointer-events-none absolute bottom-2 right-2 flex size-9 items-center justify-center text-white">
+                            <span className="pointer-events-none absolute top-2 right-2 flex size-9 items-center justify-center text-white">
                               <MdZoomIn size={23} />
                             </span>
                           </button>

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -1,6 +1,8 @@
 import facilityService from "@/api/services/facilityService";
+import ImagePreview from "@/components/booking/ImagePreview";
 import ministryService from "@/api/services/ministryService";
 import type { MinistryItem } from "@/types/ministry";
+import { canOpenImagePreview } from "@/utils/imagePreview";
 import {
   isWhenValid,
   parseBookingDetailsQuery,
@@ -48,7 +50,7 @@ import dayjs from "dayjs";
 import moment from "moment";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { MdArrowBack, MdArrowForward } from "react-icons/md";
+import { MdArrowBack, MdArrowForward, MdPhoto, MdZoomIn } from "react-icons/md";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
 
 const ROOMS_PER_PAGE = 4;
@@ -156,6 +158,7 @@ const RoomFilterPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hover, setHover] = useState<HoverPreview | null>(null);
+  const [previewUrls, setPreviewUrls] = useState<string[] | null>(null);
   const gridScrollRef = useRef<HTMLDivElement>(null);
 
   const appliedQuery = initialQuery;
@@ -605,7 +608,28 @@ const RoomFilterPage = () => {
                 paddedRooms.map((room, index) =>
                   room ? (
                     <article className="min-w-0 overflow-hidden bg-booking-primary" key={room.id}>
-                      <div className="h-[150px] w-full bg-booking-grey" />
+                      <div className="relative h-[150px] w-full bg-booking-grey">
+                        {canOpenImagePreview(room.photoUrls) ? (
+                          <button
+                            aria-label={t("imagePreview.zoom")}
+                            className="relative h-full w-full p-0"
+                            onClick={() => setPreviewUrls(room.photoUrls)}
+                            type="button"
+                          >
+                            <img alt="" className="size-full object-cover" src={room.photoUrls[0]} />
+                            <span className="pointer-events-none absolute bottom-2 right-2 flex size-9 items-center justify-center text-white">
+                              <MdZoomIn size={23} />
+                            </span>
+                          </button>
+                        ) : (
+                          <div
+                            aria-hidden
+                            className="flex size-full items-center justify-center text-booking-primary/40"
+                          >
+                            <MdPhoto size={48} />
+                          </div>
+                        )}
+                      </div>
                       <div className="flex items-center justify-between gap-2 px-[15px] py-3">
                         <span className="truncate text-base font-bold leading-none text-white">{room.name}</span>
                         <span className="flex shrink-0 items-center gap-[5px] text-xs font-medium text-brand-100">
@@ -731,6 +755,7 @@ const RoomFilterPage = () => {
           )}
         </div>
       </section>
+      {previewUrls ? <ImagePreview onClose={() => setPreviewUrls(null)} photoUrls={previewUrls} /> : null}
     </main>
   );
 };

--- a/src/utils/availabilityMapper.test.ts
+++ b/src/utils/availabilityMapper.test.ts
@@ -32,6 +32,41 @@ describe("mapAvailabilityToRoomDays", () => {
     expect(rooms[0]?.cells.find((cell) => cell.start === "11:00")?.state).toBe("override");
   });
 
+  it("maps photoUrls onto the room header photos", () => {
+    const rooms = mapAvailabilityToRoomDays({
+      date: "2026-07-20",
+      items: [
+        {
+          id: "gym-id",
+          code: "gym",
+          name: "Gym",
+          capacity: 200,
+          photoUrls: ["https://cdn.example/a.jpg", "https://cdn.example/b.jpg"],
+          cells: [{ start: "09:00", end: "09:30", state: "available" }],
+        },
+        {
+          id: "chapel-id",
+          code: "chapel",
+          name: "Chapel",
+          capacity: 10,
+          photo_urls: ["https://cdn.example/c.jpg"],
+          cells: [{ start: "09:00", end: "09:30", state: "available" }],
+        },
+        {
+          id: "office-id",
+          code: "office",
+          name: "Office",
+          capacity: 4,
+          cells: [{ start: "09:00", end: "09:30", state: "available" }],
+        },
+      ],
+    });
+
+    expect(rooms[0]?.photoUrls).toEqual(["https://cdn.example/a.jpg", "https://cdn.example/b.jpg"]);
+    expect(rooms[1]?.photoUrls).toEqual(["https://cdn.example/c.jpg"]);
+    expect(rooms[2]?.photoUrls).toEqual([]);
+  });
+
   it("expands availability.am/pm hour windows into available 30-minute cells", () => {
     const rooms = mapAvailabilityToRoomDays({
       date: "2026-08-26",

--- a/src/utils/availabilityMapper.ts
+++ b/src/utils/availabilityMapper.ts
@@ -31,6 +31,8 @@ interface ApiRoomAvailabilityItem {
   code: string;
   name?: string | null;
   capacity?: number | null;
+  photoUrls?: string[];
+  photo_urls?: string[];
   templates?: ApiTemplateWindow[];
   cells?: ApiTimeCell[];
   availability?: {
@@ -156,6 +158,7 @@ export const mapAvailabilityToRoomDays = (payload: ApiRoomAvailabilityList): Roo
       code: item.code,
       name: item.name || item.code,
       capacity: item.capacity ?? 0,
+      photoUrls: (item.photoUrls ?? item.photo_urls ?? []).filter((url) => url.length > 0),
       templates,
       cells: closedDayCells().map((cell) => byStart.get(cell.start) ?? cell),
     };

--- a/src/utils/imagePreview.test.ts
+++ b/src/utils/imagePreview.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { canOpenImagePreview, nextPreviewIndex, previousPreviewIndex } from "./imagePreview";
+
+describe("canOpenImagePreview", () => {
+  it("does not open when there are no photos", () => {
+    expect(canOpenImagePreview([])).toBe(false);
+  });
+
+  it("opens when the room has at least one photo", () => {
+    expect(canOpenImagePreview(["https://cdn.example/a.jpg"])).toBe(true);
+  });
+});
+
+describe("preview index", () => {
+  it("stays on the only photo when prev or next is requested", () => {
+    expect(previousPreviewIndex(0, 1)).toBe(0);
+    expect(nextPreviewIndex(0, 1)).toBe(0);
+  });
+
+  it("cycles through multiple photos", () => {
+    expect(nextPreviewIndex(0, 3)).toBe(1);
+    expect(nextPreviewIndex(2, 3)).toBe(0);
+    expect(previousPreviewIndex(0, 3)).toBe(2);
+    expect(previousPreviewIndex(1, 3)).toBe(0);
+  });
+});

--- a/src/utils/imagePreview.ts
+++ b/src/utils/imagePreview.ts
@@ -1,0 +1,17 @@
+export const canOpenImagePreview = (photoUrls: string[]): boolean => {
+  return photoUrls.length > 0;
+};
+
+export const nextPreviewIndex = (index: number, count: number): number => {
+  if (count <= 1) {
+    return 0;
+  }
+  return (index + 1) % count;
+};
+
+export const previousPreviewIndex = (index: number, count: number): number => {
+  if (count <= 1) {
+    return 0;
+  }
+  return (index - 1 + count) % count;
+};

--- a/src/utils/timetableRules.test.ts
+++ b/src/utils/timetableRules.test.ts
@@ -42,6 +42,7 @@ const gym = (overrides: Partial<RoomDay> = {}): RoomDay => ({
   code: "gym",
   name: "Gym",
   capacity: 200,
+  photoUrls: [],
   templates: [{ start: "09:00", end: "17:00", slotDurationMinutes: 60 }],
   cells: gymCells(),
   ...overrides,
@@ -52,6 +53,7 @@ const chapel = (): RoomDay => ({
   code: "chapel",
   name: "Chapel",
   capacity: 10,
+  photoUrls: [],
   templates: [{ start: "09:00", end: "12:00", slotDurationMinutes: 60 }],
   cells: gymCells({
     "12:00": "closed",
@@ -72,6 +74,7 @@ const sanctuary = (): RoomDay => ({
   code: "sanctuary-hall",
   name: "Sanctuary",
   capacity: 25,
+  photoUrls: [],
   templates: [{ start: "09:00", end: "17:00", slotDurationMinutes: 60 }],
   cells: gymCells(),
 });

--- a/src/utils/timetableRules.ts
+++ b/src/utils/timetableRules.ts
@@ -29,6 +29,7 @@ export interface RoomDay {
   code: string;
   name: string;
   capacity: number;
+  photoUrls: string[];
   templates: RoomTemplateWindow[];
   cells: TimeCell[];
 }


### PR DESCRIPTION
## Summary

Timetable column headers now show availability `photoUrls`. Rooms with photos open Image preview from the header (zoom control at the top right). Empty `photoUrls` show a photo icon and do not open the overlay. Close returns to the Timetable without changing selection.

Closes #21

## Type of change

- [x] New feature or API

## Implementation notes

- Maps camelCase `photoUrls` (and snake_case `photo_urls`) onto `RoomDay`.
- One photo hides thumbs and prev/next; multiple photos cycle.
- Overlay is named Image preview, not Gallery.

## Testing

- [x] `pnpm test`
- [x] `pnpm run type-check`
- [ ] Timetable: room with photos — header image, zoom top-right, overlay, close
- [ ] Timetable: room with empty `photoUrls` — photo icon, preview does not open
- [ ] Multiple photos: thumbs and prev/next cycle; selection unchanged after close

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)