### PR TITLE
feat: open Confirm Booking Time on Single BOOK

### DIFF
--- a/src/components/booking/ConfirmBookingTime.tsx
+++ b/src/components/booking/ConfirmBookingTime.tsx
@@ -1,0 +1,124 @@
+import { canConfirmBookingTime, type BookingInterval, type RoomDay } from "@/utils/timetableRules";
+import {
+  Button,
+  DatePicker,
+  Modal,
+  TimePicker,
+  type DatePickerValue,
+  type TimePickerValue,
+} from "@efcnewlife/newlife-ui";
+import dayjs from "dayjs";
+import { useTranslation } from "react-i18next";
+
+const TIME_OF_DAY_ANCHOR = "1970-01-01";
+
+const toTimePickerValue = (clock: string): TimePickerValue => {
+  if (!clock || clock === "24:00") {
+    return null;
+  }
+  const parsed = dayjs(`${TIME_OF_DAY_ANCHOR}T${clock}:00`);
+  if (!parsed.isValid()) {
+    return null;
+  }
+  return parsed;
+};
+
+const fromTimePickerValue = (value: TimePickerValue): string => {
+  if (!value || !value.isValid()) {
+    return "";
+  }
+  return value.format("HH:mm");
+};
+
+const toDatePickerValue = (date: string): DatePickerValue => {
+  if (!date) {
+    return null;
+  }
+  const parsed = dayjs(date);
+  if (!parsed.isValid() || parsed.format("YYYY-MM-DD") !== date) {
+    return null;
+  }
+  return parsed;
+};
+
+interface ConfirmBookingTimeProps {
+  date: string;
+  room: RoomDay;
+  start: string;
+  end: string;
+  onStartChange: (start: string) => void;
+  onEndChange: (end: string) => void;
+  onCancel: () => void;
+  onConfirm: (interval: BookingInterval) => void;
+}
+
+const ConfirmBookingTime = ({
+  date,
+  room,
+  start,
+  end,
+  onStartChange,
+  onEndChange,
+  onCancel,
+  onConfirm,
+}: ConfirmBookingTimeProps) => {
+  const { t } = useTranslation("booking");
+  const interval: BookingInterval | null = start && end ? { start, end } : null;
+  const canContinue = canConfirmBookingTime(room, interval);
+
+  return (
+    <Modal
+      footer={
+        <>
+          <Button onClick={onCancel} size="sm" variant="outline">
+            {t("confirmBookingTime.cancel")}
+          </Button>
+          <Button
+            disabled={!canContinue}
+            onClick={() => {
+              if (interval && canContinue) {
+                onConfirm(interval);
+              }
+            }}
+            size="sm"
+            variant="primary"
+          >
+            {t("confirmBookingTime.confirm")}
+          </Button>
+        </>
+      }
+      isOpen
+      onClose={onCancel}
+      title={t("confirmBookingTime.title")}
+    >
+      <div className="flex flex-wrap gap-4">
+        <DatePicker
+          clearable={false}
+          disabled
+          id="confirm-booking-date"
+          label={t("confirmBookingTime.date")}
+          value={toDatePickerValue(date)}
+          wrapperClassName="w-[148px] shrink-0"
+        />
+        <TimePicker
+          ampm
+          id="confirm-booking-start"
+          label={t("confirmBookingTime.start")}
+          onChange={(value) => onStartChange(fromTimePickerValue(value))}
+          value={toTimePickerValue(start)}
+          wrapperClassName="w-[148px] shrink-0"
+        />
+        <TimePicker
+          ampm
+          id="confirm-booking-end"
+          label={t("confirmBookingTime.end")}
+          onChange={(value) => onEndChange(fromTimePickerValue(value))}
+          value={toTimePickerValue(end)}
+          wrapperClassName="w-[148px] shrink-0"
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmBookingTime;

--- a/src/components/booking/ConfirmBookingTime.tsx
+++ b/src/components/booking/ConfirmBookingTime.tsx
@@ -1,12 +1,5 @@
 import { canConfirmBookingTime, type BookingInterval, type RoomDay } from "@/utils/timetableRules";
-import {
-  Button,
-  DatePicker,
-  Modal,
-  TimePicker,
-  type DatePickerValue,
-  type TimePickerValue,
-} from "@efcnewlife/newlife-ui";
+import { Button, Modal, TimePicker, type TimePickerValue } from "@efcnewlife/newlife-ui";
 import dayjs from "dayjs";
 import { useTranslation } from "react-i18next";
 
@@ -28,17 +21,6 @@ const fromTimePickerValue = (value: TimePickerValue): string => {
     return "";
   }
   return value.format("HH:mm");
-};
-
-const toDatePickerValue = (date: string): DatePickerValue => {
-  if (!date) {
-    return null;
-  }
-  const parsed = dayjs(date);
-  if (!parsed.isValid() || parsed.format("YYYY-MM-DD") !== date) {
-    return null;
-  }
-  return parsed;
 };
 
 interface ConfirmBookingTimeProps {
@@ -68,6 +50,7 @@ const ConfirmBookingTime = ({
 
   return (
     <Modal
+      className="mx-4 w-full max-w-md p-6"
       footer={
         <>
           <Button onClick={onCancel} size="sm" variant="outline">
@@ -91,31 +74,29 @@ const ConfirmBookingTime = ({
       onClose={onCancel}
       title={t("confirmBookingTime.title")}
     >
-      <div className="flex flex-wrap gap-4">
-        <DatePicker
-          clearable={false}
-          disabled
-          id="confirm-booking-date"
-          label={t("confirmBookingTime.date")}
-          value={toDatePickerValue(date)}
-          wrapperClassName="w-[148px] shrink-0"
-        />
-        <TimePicker
-          ampm
-          id="confirm-booking-start"
-          label={t("confirmBookingTime.start")}
-          onChange={(value) => onStartChange(fromTimePickerValue(value))}
-          value={toTimePickerValue(start)}
-          wrapperClassName="w-[148px] shrink-0"
-        />
-        <TimePicker
-          ampm
-          id="confirm-booking-end"
-          label={t("confirmBookingTime.end")}
-          onChange={(value) => onEndChange(fromTimePickerValue(value))}
-          value={toTimePickerValue(end)}
-          wrapperClassName="w-[148px] shrink-0"
-        />
+      <div className="flex flex-col gap-4">
+        <p className="m-0 text-lg text-on-surface">
+          <span className="font-medium">{t("confirmBookingTime.date")}: </span>
+          <span>{date}</span>
+        </p>
+        <div className="grid grid-cols-2 gap-4">
+          <TimePicker
+            ampm
+            id="confirm-booking-start"
+            label={t("confirmBookingTime.start")}
+            onChange={(value) => onStartChange(fromTimePickerValue(value))}
+            value={toTimePickerValue(start)}
+            wrapperClassName="w-full min-w-0"
+          />
+          <TimePicker
+            ampm
+            id="confirm-booking-end"
+            label={t("confirmBookingTime.end")}
+            onChange={(value) => onEndChange(fromTimePickerValue(value))}
+            value={toTimePickerValue(end)}
+            wrapperClassName="w-full min-w-0"
+          />
+        </div>
       </div>
     </Modal>
   );

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -89,6 +89,7 @@
     "previousRooms": "Previous rooms",
     "nextRooms": "Next rooms",
     "book": "BOOK",
+    "add": "ADD",
     "available": "Available",
     "unavailable": "Unavailable",
     "closed": "Closed",
@@ -104,6 +105,14 @@
     "whenInvalid": "Choose a date from today through one year ahead. If Time is set, it must stay on that day and start before end.",
     "errorTitle": "Unable to continue",
     "successTitle": "Booking created"
+  },
+  "confirmBookingTime": {
+    "title": "Confirm Booking Time",
+    "date": "Date",
+    "start": "Start Time",
+    "end": "End Time",
+    "cancel": "Cancel",
+    "confirm": "Confirm"
   },
   "bookingDetails": {
     "title": "Booking Details",

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -89,6 +89,7 @@
     "previousRooms": "上一组房间",
     "nextRooms": "下一组房间",
     "book": "预订",
+    "add": "加入",
     "available": "可预订",
     "unavailable": "不可预订",
     "closed": "关闭",
@@ -104,6 +105,14 @@
     "whenInvalid": "日期需为今天起一年内。若填写时间，须在同一天且开始早于结束。",
     "errorTitle": "无法继续",
     "successTitle": "预订已创建"
+  },
+  "confirmBookingTime": {
+    "title": "确认预订时间",
+    "date": "日期",
+    "start": "开始时间",
+    "end": "结束时间",
+    "cancel": "取消",
+    "confirm": "确认"
   },
   "bookingDetails": {
     "title": "预订详情",

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -89,6 +89,7 @@
     "previousRooms": "上一組房間",
     "nextRooms": "下一組房間",
     "book": "預訂",
+    "add": "加入",
     "available": "可預訂",
     "unavailable": "不可預訂",
     "closed": "關閉",
@@ -104,6 +105,14 @@
     "whenInvalid": "日期需為今天起一年內。若有填寫時間，須在同一天且開始早於結束。",
     "errorTitle": "無法繼續",
     "successTitle": "預訂已建立"
+  },
+  "confirmBookingTime": {
+    "title": "確認預訂時間",
+    "date": "日期",
+    "start": "開始時間",
+    "end": "結束時間",
+    "cancel": "取消",
+    "confirm": "確認"
   },
   "bookingDetails": {
     "title": "預訂詳情",

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -16,9 +16,9 @@ import {
 import {
   bookRoom,
   canReviewBooking,
-  confirmBookingTimePrefill,
   clearUnconfirmedSelection,
   clockToMinutes,
+  confirmBookingTimePrefill,
   displayBlocks,
   emptyTimeBookInterval,
   emptyTimePointerAction,

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -1,5 +1,6 @@
 import facilityService from "@/api/services/facilityService";
 import ministryService from "@/api/services/ministryService";
+import ConfirmBookingTime from "@/components/booking/ConfirmBookingTime";
 import ImagePreview from "@/components/booking/ImagePreview";
 import type { MinistryItem } from "@/types/ministry";
 import { canOpenImagePreview } from "@/utils/imagePreview";
@@ -15,6 +16,7 @@ import {
 import {
   bookRoom,
   canReviewBooking,
+  confirmBookingTimePrefill,
   clearUnconfirmedSelection,
   clockToMinutes,
   displayBlocks,
@@ -26,6 +28,7 @@ import {
   scrollTargetClock,
   SLOT_MINUTES,
   visibleRooms,
+  type BookingInterval,
   type CapacityBand,
   type CellState,
   type HoverPreview,
@@ -158,6 +161,9 @@ const RoomFilterPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hover, setHover] = useState<HoverPreview | null>(null);
+  const [confirmRoom, setConfirmRoom] = useState<RoomDay | null>(null);
+  const [confirmStart, setConfirmStart] = useState("");
+  const [confirmEnd, setConfirmEnd] = useState("");
   const [previewUrls, setPreviewUrls] = useState<string[] | null>(null);
   const gridScrollRef = useRef<HTMLDivElement>(null);
 
@@ -334,7 +340,7 @@ const RoomFilterPage = () => {
     return <Navigate replace to="/" />;
   }
 
-  const handleBook = (room: RoomDay, cellStart: string) => {
+  const handleAdd = (room: RoomDay, cellStart: string) => {
     if (!isBookableCell(room, cellStart, selection.interval)) {
       return;
     }
@@ -345,6 +351,52 @@ const RoomFilterPage = () => {
       setDraftStart(next.interval.start);
       setDraftEnd(next.interval.end);
     }
+  };
+
+  const handleOpenConfirmBookingTime = (room: RoomDay, cellStart: string) => {
+    if (!isBookableCell(room, cellStart, selection.interval)) {
+      return;
+    }
+    const prefill = confirmBookingTimePrefill(room, cellStart, selection.interval);
+    if (!prefill) {
+      return;
+    }
+    setHover(null);
+    setConfirmRoom(room);
+    setConfirmStart(prefill.start);
+    setConfirmEnd(prefill.end);
+  };
+
+  const handleAvailableAction = (room: RoomDay, cellStart: string) => {
+    if (appliedSpace === "single") {
+      handleOpenConfirmBookingTime(room, cellStart);
+      return;
+    }
+    handleAdd(room, cellStart);
+  };
+
+  const handleCancelConfirmBookingTime = () => {
+    setConfirmRoom(null);
+    setConfirmStart("");
+    setConfirmEnd("");
+  };
+
+  const handleConfirmBookingTime = (interval: BookingInterval) => {
+    if (!confirmRoom || !appliedDate) {
+      return;
+    }
+    navigate({
+      pathname: "/booking-details",
+      search: toBookingDetailsSearchParams({
+        date: appliedDate,
+        start: interval.start,
+        end: interval.end,
+        space: appliedSpace,
+        roomIds: [confirmRoom.id],
+        ...(appliedMinistryId ? { ministryId: appliedMinistryId } : {}),
+        ...(appliedRoom ? { room: appliedRoom } : {}),
+      }).toString(),
+    });
   };
 
   const pointerKindFromEvent = (event: { pointerType: string }): PointerKind => {
@@ -371,7 +423,7 @@ const RoomFilterPage = () => {
       setHover(target);
       return;
     }
-    handleBook(room, cellStart);
+    handleAvailableAction(room, cellStart);
   };
 
   const handleReviewBooking = () => {
@@ -559,16 +611,16 @@ const RoomFilterPage = () => {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-4">
-            <Button
-              className="whitespace-nowrap !border-[0.5px] !border-booking-primary !bg-cta !text-on-cta hover:!bg-cta hover:!text-on-cta"
-              disabled={!canReviewBooking(selection)}
-              onClick={handleReviewBooking}
-              size="xs"
-            >
-              {appliedSpace === "multiple"
-                ? t("timetable.reviewBookingCount", { count: selection.roomIds.length })
-                : t("timetable.reviewBooking")}
-            </Button>
+            {appliedSpace === "multiple" ? (
+              <Button
+                className="whitespace-nowrap !border-[0.5px] !border-booking-primary !bg-cta !text-on-cta hover:!bg-cta hover:!text-on-cta"
+                disabled={!canReviewBooking(selection)}
+                onClick={handleReviewBooking}
+                size="xs"
+              >
+                {t("timetable.reviewBookingCount", { count: selection.roomIds.length })}
+              </Button>
+            ) : null}
             <div className="flex shrink-0 gap-3">
               <Button
                 className="min-w-10"
@@ -708,7 +760,7 @@ const RoomFilterPage = () => {
                           }}
                           onClick={() => {
                             if (room && cell) {
-                              handleBook(room, cell.start);
+                              handleAvailableAction(room, cell.start);
                             }
                           }}
                           style={{ gridColumn: roomIndex + 2, gridRow: cellIndex + 1 }}
@@ -739,10 +791,10 @@ const RoomFilterPage = () => {
                           {block.state === "available" && bookableStart ? (
                             <button
                               className="pointer-events-auto inline-flex h-[30px] w-[51px] min-w-[51px] items-center justify-center rounded-[3px] bg-booking-secondary p-0 text-[11.5px] font-bold text-white"
-                              onClick={() => handleBook(room, block.start)}
+                              onClick={() => handleAvailableAction(room, block.start)}
                               type="button"
                             >
-                              {t("timetable.book")}
+                              {t(appliedSpace === "multiple" ? "timetable.add" : "timetable.book")}
                             </button>
                           ) : null}
                         </article>
@@ -755,6 +807,18 @@ const RoomFilterPage = () => {
           )}
         </div>
       </section>
+      {confirmRoom ? (
+        <ConfirmBookingTime
+          date={appliedDate}
+          end={confirmEnd}
+          onCancel={handleCancelConfirmBookingTime}
+          onConfirm={handleConfirmBookingTime}
+          onEndChange={setConfirmEnd}
+          onStartChange={setConfirmStart}
+          room={confirmRoom}
+          start={confirmStart}
+        />
+      ) : null}
       {previewUrls ? <ImagePreview onClose={() => setPreviewUrls(null)} photoUrls={previewUrls} /> : null}
     </main>
   );

--- a/src/utils/timetableRules.test.ts
+++ b/src/utils/timetableRules.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_SELECTED_ROOMS,
   bookRoom,
+  canConfirmBookingTime,
   canReviewBooking,
+  confirmBookingTimePrefill,
   capacityBandFor,
   clearUnconfirmedSelection,
   displayBlocks,
@@ -162,11 +164,45 @@ describe("bookRoom", () => {
     expect(next.roomIds).toHaveLength(MAX_SELECTED_ROOMS);
   });
 
-  it("replaces the shared interval when BOOK starts a different span", () => {
+  it("replaces the shared interval when ADD starts a different span", () => {
     const selected: TimetableSelection = { roomIds: ["chapel-id"], interval: { start: "10:00", end: "11:00" } };
     const next = bookRoom(selected, gym(), "14:00", "multiple");
     expect(next.interval).toEqual({ start: "14:00", end: "15:00" });
     expect(next.roomIds).toEqual(["gym-id"]);
+  });
+});
+
+describe("confirmBookingTimePrefill", () => {
+  it("prefills the existing Booking interval pair", () => {
+    expect(confirmBookingTimePrefill(gym(), "09:30", { start: "10:00", end: "11:30" })).toEqual({
+      start: "10:00",
+      end: "11:30",
+    });
+  });
+
+  it("prefills Slot start plus Template duration when Time is empty", () => {
+    expect(confirmBookingTimePrefill(gym(), "09:30", null)).toEqual({ start: "09:30", end: "10:30" });
+  });
+});
+
+describe("canConfirmBookingTime", () => {
+  it("rejects an interval shorter than Template duration", () => {
+    expect(canConfirmBookingTime(gym(), { start: "10:00", end: "10:30" })).toBe(false);
+  });
+
+  it("rejects Closed or Unavailable coverage", () => {
+    const occupied = gym({ cells: gymCells({ "10:00": "unavailable", "10:30": "unavailable" }) });
+    expect(canConfirmBookingTime(occupied, { start: "10:00", end: "11:00" })).toBe(false);
+    expect(canConfirmBookingTime(gym(), { start: "07:00", end: "08:00" })).toBe(false);
+  });
+
+  it("rejects overnight or inverted times", () => {
+    expect(canConfirmBookingTime(gym(), { start: "23:00", end: "01:00" })).toBe(false);
+    expect(canConfirmBookingTime(gym(), { start: "11:00", end: "10:00" })).toBe(false);
+  });
+
+  it("allows a valid same-day interval", () => {
+    expect(canConfirmBookingTime(gym(), { start: "10:00", end: "11:30" })).toBe(true);
   });
 });
 

--- a/src/utils/timetableRules.ts
+++ b/src/utils/timetableRules.ts
@@ -135,6 +135,27 @@ export const isBookableCell = (room: RoomDay, cellStart: string, interval: Booki
   return emptyTimeBookInterval(room, cellStart) != null;
 };
 
+export const confirmBookingTimePrefill = (
+  room: RoomDay,
+  cellStart: string,
+  existing: BookingInterval | null
+): BookingInterval | null => {
+  if (existing) {
+    return existing;
+  }
+  return emptyTimeBookInterval(room, cellStart);
+};
+
+export const canConfirmBookingTime = (room: RoomDay, interval: BookingInterval | null): boolean => {
+  if (!interval) {
+    return false;
+  }
+  if (clockToMinutes(interval.end) <= clockToMinutes(interval.start)) {
+    return false;
+  }
+  return isRoomAvailable(room, interval);
+};
+
 export const bookRoom = (
   selection: TimetableSelection,
   room: RoomDay,


### PR DESCRIPTION
## Summary

Single BOOK always opens Confirm Booking Time (read-only date, editable start/end), then Booking Details via the query draft. Multiple uses ADD and Review Booking (n). Cancel does not select a room or change the interval; invalid intervals cannot continue.

Closes #22

## Type of change

- [x] New feature or API

## Implementation notes

Confirm Booking Time is a compact overlay: `Date: YYYY-MM-DD` on one row, Start Time and End Time side by side. Different-span ADD still replaces the shared Booking interval and keeps only that room.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] `pnpm run format:check` (CI)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge


Made with [Cursor](https://cursor.com)