### PR TITLE
feat: show Booking Details Payment Summary from Preview quote

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -22,6 +22,7 @@ export const API_ENDPOINTS = {
   FACILITY: {
     AVAILABILITY: `${BOOKING_API_PREFIX}/facility/rooms/availability`,
     BOOKINGS: `${BOOKING_API_PREFIX}/facility/bookings`,
+    PREVIEW_QUOTE: `${BOOKING_API_PREFIX}/facility/preview-quote`,
     MY_BOOKINGS: `${BOOKING_API_PREFIX}/facility/bookings/mine`,
     booking: (bookingId: string) => `${BOOKING_API_PREFIX}/facility/bookings/${bookingId}`,
     cancelBooking: (bookingId: string) => `${BOOKING_API_PREFIX}/facility/bookings/${bookingId}/cancel`,

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -18,6 +18,34 @@ interface CreateBookingPayload {
   remark?: string;
 }
 
+interface PreviewQuotePayload {
+  startAt: string;
+  endAt: string;
+  ministryId?: string | null;
+  isMissionAligned?: boolean;
+  rooms: Array<{ facilityId: string }>;
+}
+
+interface ApiPreviewQuote {
+  subtotalAmount?: string | number | null;
+  subtotal_amount?: string | number | null;
+  discountAmount?: string | number | null;
+  discount_amount?: string | number | null;
+  surchargeAmount?: string | number | null;
+  surcharge_amount?: string | number | null;
+  quotedAmount?: string | number | null;
+  quoted_amount?: string | number | null;
+  currency?: string | null;
+}
+
+export interface MemberPreviewQuote {
+  subtotalAmount: string | number | null;
+  discountAmount: string | number | null;
+  surchargeAmount: string | number | null;
+  quotedAmount: string | number | null;
+  currency: string | null;
+}
+
 interface ApiBookingDetail {
   id?: string;
   status?: string;
@@ -54,6 +82,21 @@ class FacilityService {
       throw new Error(response.message || "Failed to load availability");
     }
     return mapAvailabilityToRoomDays(response.data);
+  }
+
+  async previewQuote(payload: PreviewQuotePayload): Promise<MemberPreviewQuote> {
+    const response = await httpClient.post<ApiPreviewQuote>(API_ENDPOINTS.FACILITY.PREVIEW_QUOTE, payload);
+    if (!response.success || !response.data) {
+      throw new Error(response.message || "Failed to load preview quote");
+    }
+    const data = response.data;
+    return {
+      subtotalAmount: data.subtotalAmount ?? data.subtotal_amount ?? null,
+      discountAmount: data.discountAmount ?? data.discount_amount ?? null,
+      surchargeAmount: data.surchargeAmount ?? data.surcharge_amount ?? null,
+      quotedAmount: data.quotedAmount ?? data.quoted_amount ?? null,
+      currency: data.currency ?? null,
+    };
   }
 
   async createBooking(payload: CreateBookingPayload): Promise<{ id: string }> {

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -128,6 +128,7 @@
     "paymentSummary": "Payment Summary",
     "rate": "Rate",
     "ministryDiscount": "Ministry discount",
+    "surcharge": "Surcharge",
     "subtotal": "Subtotal",
     "tax": "HST Tax",
     "total": "Total"

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -128,6 +128,7 @@
     "paymentSummary": "付款摘要",
     "rate": "费率",
     "ministryDiscount": "事工折扣",
+    "surcharge": "附加费",
     "subtotal": "小计",
     "tax": "HST 税",
     "total": "总计"

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -128,6 +128,7 @@
     "paymentSummary": "付款摘要",
     "rate": "費率",
     "ministryDiscount": "事工折扣",
+    "surcharge": "附加費",
     "subtotal": "小計",
     "tax": "HST 稅",
     "total": "總計"

--- a/src/pages/booking-details/BookingDetailsPage.tsx
+++ b/src/pages/booking-details/BookingDetailsPage.tsx
@@ -1,4 +1,5 @@
 import facilityService from "@/api/services/facilityService";
+import { mapPaymentSummary, type PaymentSummaryLabels } from "@/utils/paymentSummary";
 import {
   parseBookingDetailsQuery,
   parseRoomsSearchQuery,
@@ -12,8 +13,6 @@ import moment from "moment";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
-
-const DASH = "—";
 
 const combineDateAndTime = (date: string, time: string): string => {
   const clock = time === "24:00" ? "00:00" : time;
@@ -41,6 +40,11 @@ const messageFromUnknown = (err: unknown, fallback: string): string => {
   return fallback;
 };
 
+const bookingIntervalIso = (query: BookingDetailsQuery): { startAt: string; endAt: string } => ({
+  startAt: combineDateAndTime(query.date, query.start),
+  endAt: combineDateAndTime(query.date, query.end),
+});
+
 const selectedRoomsCoverInterval = (rooms: RoomDay[], query: BookingDetailsQuery): boolean => {
   const interval = { start: query.start, end: query.end };
   return query.roomIds.every((roomId) => {
@@ -57,30 +61,47 @@ const BookingDetailsPage = () => {
   const roomsSearch = useMemo(() => parseRoomsSearchQuery(searchParams), [searchParams]);
 
   const [rooms, setRooms] = useState<RoomDay[]>([]);
+  const [paymentSummary, setPaymentSummary] = useState<PaymentSummaryLabels>(() =>
+    mapPaymentSummary(null, i18nInstance.language)
+  );
   const [loading, setLoading] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const loadAvailability = useCallback(async () => {
+  const loadDraft = useCallback(async () => {
     if (!query) {
       return;
     }
     setLoading(true);
     setError(null);
+    setPaymentSummary(mapPaymentSummary(null, i18nInstance.language));
     try {
       const items = await facilityService.getAvailability(query.date, query.ministryId);
       setRooms(items);
     } catch (err) {
       setError(messageFromUnknown(err, t("timetable.loadError")));
       setRooms([]);
+    }
+    try {
+      const { startAt, endAt } = bookingIntervalIso(query);
+      const quote = await facilityService.previewQuote({
+        startAt,
+        endAt,
+        ministryId: query.ministryId || null,
+        isMissionAligned: Boolean(query.ministryId),
+        rooms: query.roomIds.map((facilityId) => ({ facilityId })),
+      });
+      setPaymentSummary(mapPaymentSummary(quote, i18nInstance.language));
+    } catch {
+      setPaymentSummary(mapPaymentSummary(null, i18nInstance.language));
     } finally {
       setLoading(false);
     }
-  }, [query, t]);
+  }, [i18nInstance.language, query, t]);
 
   useEffect(() => {
-    void loadAvailability();
-  }, [loadAvailability]);
+    void loadDraft();
+  }, [loadDraft]);
 
   const canConfirm = useMemo(() => {
     if (!query || loading || confirming) {
@@ -120,12 +141,12 @@ const BookingDetailsPage = () => {
     setConfirming(true);
     setError(null);
     try {
-      const startAt = combineDateAndTime(query.date, query.start);
-      const endAt = combineDateAndTime(query.date, query.end);
+      const { startAt, endAt } = bookingIntervalIso(query);
       const created = await facilityService.createBooking({
         startAt,
         endAt,
         ministryId: query.ministryId || null,
+        isMissionAligned: Boolean(query.ministryId),
         rooms: query.roomIds.map((facilityId, index) => ({
           facilityId,
           startAt,
@@ -214,26 +235,30 @@ const BookingDetailsPage = () => {
           <div className="flex w-full flex-col items-center gap-[15px] rounded-[10px] border border-booking-grey bg-booking-bg px-[25px] py-10">
             <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
               <span>{t("bookingDetails.rate")}</span>
-              <span>{DASH}</span>
+              <span>{paymentSummary.rate}</span>
             </div>
             <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
               <span>{t("bookingDetails.ministryDiscount")}</span>
-              <span>{DASH}</span>
+              <span>{paymentSummary.ministryDiscount}</span>
+            </div>
+            <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
+              <span>{t("bookingDetails.surcharge")}</span>
+              <span>{paymentSummary.surcharge}</span>
             </div>
             <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
             <div className="flex w-[233px] justify-between text-base font-bold leading-5 text-booking-primary">
               <span>{t("bookingDetails.subtotal")}</span>
-              <span>{DASH}</span>
+              <span>{paymentSummary.subtotal}</span>
             </div>
             <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
             <div className="flex w-[233px] justify-between text-base leading-5 text-booking-primary">
               <span>{t("bookingDetails.tax")}</span>
-              <span>{DASH}</span>
+              <span>{paymentSummary.tax}</span>
             </div>
             <hr className="m-0 w-[260px] border-0 border-t border-gray-300" />
             <div className="flex w-[233px] justify-between text-base font-bold leading-5 text-booking-primary">
               <span>{t("bookingDetails.total")}</span>
-              <span>{DASH}</span>
+              <span>{paymentSummary.total}</span>
             </div>
             <Button className="mt-1" disabled={!canConfirm} onClick={() => void handleConfirm()}>
               {t("bookingDetails.confirm")}

--- a/src/utils/paymentSummary.test.ts
+++ b/src/utils/paymentSummary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mapPaymentSummary } from "./paymentSummary";
+
+const EM_DASH = "—";
+
+describe("mapPaymentSummary", () => {
+  it("uses em dashes when the Preview quote is missing", () => {
+    expect(mapPaymentSummary(null, "en-CA")).toEqual({
+      rate: EM_DASH,
+      ministryDiscount: EM_DASH,
+      surcharge: EM_DASH,
+      subtotal: EM_DASH,
+      tax: EM_DASH,
+      total: EM_DASH,
+    });
+  });
+
+  it("maps Preview quote money fields and leaves tax as an em dash", () => {
+    expect(
+      mapPaymentSummary(
+        {
+          subtotalAmount: "150.00",
+          discountAmount: "22.50",
+          surchargeAmount: "5.00",
+          quotedAmount: "132.50",
+          currency: "CAD",
+        },
+        "en-CA"
+      )
+    ).toEqual({
+      rate: "$150.00",
+      ministryDiscount: "-$22.50",
+      surcharge: "$5.00",
+      subtotal: EM_DASH,
+      tax: EM_DASH,
+      total: "$132.50",
+    });
+  });
+
+  it("does not invent HST from quoted amount", () => {
+    const summary = mapPaymentSummary(
+      {
+        subtotalAmount: "100.00",
+        discountAmount: "0",
+        surchargeAmount: "0",
+        quotedAmount: "100.00",
+        currency: "CAD",
+      },
+      "en-CA"
+    );
+    expect(summary.tax).toBe(EM_DASH);
+    expect(summary.total).toBe("$100.00");
+    expect(summary.ministryDiscount).toBe("$0.00");
+  });
+
+  it("uses em dashes for missing quote fields", () => {
+    expect(
+      mapPaymentSummary(
+        {
+          currency: "CAD",
+        },
+        "en-CA"
+      )
+    ).toEqual({
+      rate: EM_DASH,
+      ministryDiscount: EM_DASH,
+      surcharge: EM_DASH,
+      subtotal: EM_DASH,
+      tax: EM_DASH,
+      total: EM_DASH,
+    });
+  });
+});

--- a/src/utils/paymentSummary.ts
+++ b/src/utils/paymentSummary.ts
@@ -1,0 +1,74 @@
+export interface PreviewQuoteMoney {
+  subtotalAmount?: string | number | null;
+  discountAmount?: string | number | null;
+  surchargeAmount?: string | number | null;
+  quotedAmount?: string | number | null;
+  currency?: string | null;
+}
+
+export interface PaymentSummaryLabels {
+  rate: string;
+  ministryDiscount: string;
+  surcharge: string;
+  subtotal: string;
+  tax: string;
+  total: string;
+}
+
+const EM_DASH = "—";
+
+const formatQuotedAmount = (
+  quotedAmount: string | number | null | undefined,
+  currency: string | null | undefined,
+  locale: string
+): string => {
+  if (quotedAmount == null || quotedAmount === "") {
+    return EM_DASH;
+  }
+  const amount = typeof quotedAmount === "number" ? quotedAmount : Number(quotedAmount);
+  if (!Number.isFinite(amount)) {
+    return EM_DASH;
+  }
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: currency || "CAD",
+  }).format(amount);
+};
+
+const formatDiscountAmount = (
+  discountAmount: string | number | null | undefined,
+  currency: string | null | undefined,
+  locale: string
+): string => {
+  const formatted = formatQuotedAmount(discountAmount, currency, locale);
+  if (formatted === EM_DASH) {
+    return EM_DASH;
+  }
+  const amount = typeof discountAmount === "number" ? discountAmount : Number(discountAmount);
+  if (Number.isFinite(amount) && amount > 0) {
+    return `-${formatted}`;
+  }
+  return formatted;
+};
+
+export const mapPaymentSummary = (quote: PreviewQuoteMoney | null, locale: string): PaymentSummaryLabels => {
+  if (!quote) {
+    return {
+      rate: EM_DASH,
+      ministryDiscount: EM_DASH,
+      surcharge: EM_DASH,
+      subtotal: EM_DASH,
+      tax: EM_DASH,
+      total: EM_DASH,
+    };
+  }
+  const currency = quote.currency;
+  return {
+    rate: formatQuotedAmount(quote.subtotalAmount, currency, locale),
+    ministryDiscount: formatDiscountAmount(quote.discountAmount, currency, locale),
+    surcharge: formatQuotedAmount(quote.surchargeAmount, currency, locale),
+    subtotal: EM_DASH,
+    tax: EM_DASH,
+    total: formatQuotedAmount(quote.quotedAmount, currency, locale),
+  };
+};


### PR DESCRIPTION
## Summary

Booking Details Payment Summary now loads the member Preview quote on every visit (including a pasted URL) and maps backend money fields. Missing values stay an em dash; the SPA does not invent HST. Confirm still creates the booking.

Closes #24

Follow-up for minimum-fee copy: #30 (blocked on efcnewlife/newlife-core-api#88).

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Rate maps to `subtotalAmount`, ministry discount to `discountAmount`, surcharge to `surchargeAmount`, total to `quotedAmount`. Tax and post-discount subtotal stay dashes because those fields are not on the quote. Ministry drafts send `isMissionAligned` on preview and create so discount matches.

## Testing

- [x] `pnpm test`
- [x] `pnpm type-check`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)