### PR TITLE
feat: show Interac Payment after create booking

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -23,6 +23,7 @@ export const API_ENDPOINTS = {
     AVAILABILITY: `${BOOKING_API_PREFIX}/facility/rooms/availability`,
     BOOKINGS: `${BOOKING_API_PREFIX}/facility/bookings`,
     MY_BOOKINGS: `${BOOKING_API_PREFIX}/facility/bookings/mine`,
+    booking: (bookingId: string) => `${BOOKING_API_PREFIX}/facility/bookings/${bookingId}`,
     cancelBooking: (bookingId: string) => `${BOOKING_API_PREFIX}/facility/bookings/${bookingId}/cancel`,
   },
 } as const;

--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -1,4 +1,5 @@
-import { API_ENDPOINTS } from "@/api/config";
+import { API_ENDPOINTS, HTTP_STATUS } from "@/api/config";
+import type { ApiError } from "@/types/api";
 import { mapAvailabilityToRoomDays, type ApiRoomAvailabilityList } from "@/utils/availabilityMapper";
 import type { RoomDay } from "@/utils/timetableRules";
 import { httpClient } from "./httpClient";
@@ -17,6 +18,31 @@ interface CreateBookingPayload {
   remark?: string;
 }
 
+interface ApiBookingDetail {
+  id?: string;
+  status?: string;
+  quotedAmount?: string | number | null;
+  quoted_amount?: string | number | null;
+  currency?: string | null;
+}
+
+export interface MemberBookingDetail {
+  id: string;
+  quotedAmount: string | number | null;
+  currency: string | null;
+}
+
+export class BookingNotFoundError extends Error {
+  constructor() {
+    super("Booking not found");
+    this.name = "BookingNotFoundError";
+  }
+}
+
+const isApiError = (err: unknown): err is ApiError => {
+  return typeof err === "object" && err !== null && "code" in err;
+};
+
 class FacilityService {
   async getAvailability(date: string, ministryId?: string | null): Promise<RoomDay[]> {
     const params: Record<string, unknown> = { date };
@@ -32,10 +58,30 @@ class FacilityService {
 
   async createBooking(payload: CreateBookingPayload): Promise<{ id: string }> {
     const response = await httpClient.post<{ id: string }>(API_ENDPOINTS.FACILITY.BOOKINGS, payload);
-    if (!response.success || !response.data) {
+    if (!response.success || !response.data?.id) {
       throw new Error(response.message || "Failed to create booking");
     }
-    return response.data;
+    return { id: String(response.data.id) };
+  }
+
+  async getMyBooking(bookingId: string): Promise<MemberBookingDetail> {
+    try {
+      const response = await httpClient.get<ApiBookingDetail>(API_ENDPOINTS.FACILITY.booking(bookingId));
+      if (!response.success || !response.data) {
+        throw new Error(response.message || "Failed to load booking");
+      }
+      const quotedAmount = response.data.quotedAmount ?? response.data.quoted_amount ?? null;
+      return {
+        id: response.data.id || bookingId,
+        quotedAmount,
+        currency: response.data.currency ?? null,
+      };
+    } catch (err) {
+      if (isApiError(err) && err.code === HTTP_STATUS.NOT_FOUND) {
+        throw new BookingNotFoundError();
+      }
+      throw err instanceof Error ? err : new Error("Failed to load booking");
+    }
   }
 
   async listMyBookings(): Promise<unknown> {

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -132,6 +132,16 @@
     "tax": "HST Tax",
     "total": "Total"
   },
+  "payment": {
+    "title": "Payment",
+    "instructionsTitle": "Interac e-Transfer",
+    "instructions": "Send a Canada Interac e-Transfer for the total below to {{email}}. Put the booking id in the message. This page does not collect or confirm payment.",
+    "email": "booking@example.com",
+    "emailLabel": "Send to",
+    "total": "Total",
+    "backHome": "Back to Home",
+    "loadError": "Failed to load this booking."
+  },
   "support": {
     "pageTitle": "Support"
   },

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -132,6 +132,16 @@
     "tax": "HST 税",
     "total": "总计"
   },
+  "payment": {
+    "title": "付款",
+    "instructionsTitle": "Interac e-Transfer",
+    "instructions": "请将下方总金额以加拿大 Interac e-Transfer 转账至 {{email}}，并在留言中注明预订编号。本页不会代收或确认付款。",
+    "email": "booking@example.com",
+    "emailLabel": "转账至",
+    "total": "总计",
+    "backHome": "返回首页",
+    "loadError": "无法加载此预订。"
+  },
   "support": {
     "pageTitle": "支持"
   },

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -132,6 +132,16 @@
     "tax": "HST 稅",
     "total": "總計"
   },
+  "payment": {
+    "title": "付款",
+    "instructionsTitle": "Interac e-Transfer",
+    "instructions": "請將下方總金額以加拿大 Interac e-Transfer 轉帳至 {{email}}，並在訊息中註明預訂編號。本頁不會代收或確認付款。",
+    "email": "booking@example.com",
+    "emailLabel": "轉帳至",
+    "total": "總計",
+    "backHome": "返回首頁",
+    "loadError": "無法載入此預訂。"
+  },
   "support": {
     "pageTitle": "支援"
   },

--- a/src/pages/booking-details/BookingDetailsPage.tsx
+++ b/src/pages/booking-details/BookingDetailsPage.tsx
@@ -60,7 +60,6 @@ const BookingDetailsPage = () => {
   const [loading, setLoading] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [created, setCreated] = useState(false);
 
   const loadAvailability = useCallback(async () => {
     if (!query) {
@@ -84,11 +83,11 @@ const BookingDetailsPage = () => {
   }, [loadAvailability]);
 
   const canConfirm = useMemo(() => {
-    if (!query || loading || confirming || created) {
+    if (!query || loading || confirming) {
       return false;
     }
     return selectedRoomsCoverInterval(rooms, query);
-  }, [confirming, created, loading, query, rooms]);
+  }, [confirming, loading, query, rooms]);
 
   if (!query) {
     if (!roomsSearch?.date) {
@@ -112,7 +111,6 @@ const BookingDetailsPage = () => {
       return;
     }
     setSearchParams(toBookingDetailsSearchParams({ ...query, roomIds }), { replace: true });
-    setCreated(false);
   };
 
   const handleConfirm = async () => {
@@ -124,7 +122,7 @@ const BookingDetailsPage = () => {
     try {
       const startAt = combineDateAndTime(query.date, query.start);
       const endAt = combineDateAndTime(query.date, query.end);
-      await facilityService.createBooking({
+      const created = await facilityService.createBooking({
         startAt,
         endAt,
         ministryId: query.ministryId || null,
@@ -135,7 +133,7 @@ const BookingDetailsPage = () => {
           sequence: index,
         })),
       });
-      setCreated(true);
+      navigate(`/payment/${created.id}`);
     } catch (err) {
       setError(messageFromUnknown(err, t("timetable.createError")));
     } finally {
@@ -157,11 +155,6 @@ const BookingDetailsPage = () => {
           {error ? (
             <p className="mb-4 text-sm font-medium text-error" role="alert">
               {error}
-            </p>
-          ) : null}
-          {created ? (
-            <p className="mb-4 text-sm font-medium text-booking-green" role="status">
-              {t("timetable.success")}
             </p>
           ) : null}
           {intervalUncovered ? (

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,0 +1,84 @@
+import facilityService, { BookingNotFoundError } from "@/api/services/facilityService";
+import NotFoundPage from "@/pages/not-found/NotFoundPage";
+import { formatQuotedAmount, parsePaymentBookingId } from "@/utils/paymentPage";
+import { Button, Spinner } from "@efcnewlife/newlife-ui";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router";
+
+const PaymentPage = () => {
+  const { t, i18n: i18nInstance } = useTranslation("booking");
+  const navigate = useNavigate();
+  const { bookingId: bookingIdParam } = useParams();
+  const bookingId = useMemo(() => parsePaymentBookingId(bookingIdParam), [bookingIdParam]);
+
+  const [totalLabel, setTotalLabel] = useState(formatQuotedAmount(null, "CAD", i18nInstance.language));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  const loadBooking = useCallback(async () => {
+    if (!bookingId) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    try {
+      const detail = await facilityService.getMyBooking(bookingId);
+      setTotalLabel(formatQuotedAmount(detail.quotedAmount, detail.currency, i18nInstance.language));
+    } catch (err) {
+      if (err instanceof BookingNotFoundError) {
+        setNotFound(true);
+        return;
+      }
+      setError(t("payment.loadError"));
+      setTotalLabel(formatQuotedAmount(null, "CAD", i18nInstance.language));
+    } finally {
+      setLoading(false);
+    }
+  }, [bookingId, i18nInstance.language, t]);
+
+  useEffect(() => {
+    void loadBooking();
+  }, [loadBooking]);
+
+  if (!bookingId || notFound) {
+    return <NotFoundPage />;
+  }
+
+  return (
+    <main className="flex flex-1 justify-center bg-surface-container px-4 py-10">
+      <section className="flex w-full max-w-[640px] flex-col gap-8 rounded-[20px] bg-surface px-6 py-10 sm:px-12">
+        <div>
+          <h1 className="m-0 mb-2 text-[26px] font-semibold leading-none text-booking-primary">{t("payment.title")}</h1>
+          <h2 className="m-0 text-lg font-semibold text-booking-primary">{t("payment.instructionsTitle")}</h2>
+        </div>
+        {error ? (
+          <p className="m-0 text-sm font-medium text-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {loading ? <Spinner showText size="sm" text={t("startBooking.loading")} /> : null}
+        <p className="m-0 text-base leading-6 text-booking-text">
+          {t("payment.instructions", { email: t("payment.email") })}
+        </p>
+        <dl className="m-0">
+          <div className="flex justify-between gap-4 border-t border-gray-300 py-4">
+            <dt className="m-0 font-bold">{t("payment.emailLabel")}</dt>
+            <dd className="m-0">{t("payment.email")}</dd>
+          </div>
+          <div className="flex justify-between gap-4 border-t border-gray-300 py-4">
+            <dt className="m-0 font-bold">{t("payment.total")}</dt>
+            <dd className="m-0">{totalLabel}</dd>
+          </div>
+        </dl>
+        <Button onClick={() => navigate("/")} variant="primary">
+          {t("payment.backHome")}
+        </Button>
+      </section>
+    </main>
+  );
+};
+
+export default PaymentPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import LoginPage from "@/pages/login/LoginPage";
 import MyBookingsPage from "@/pages/my-bookings/MyBookingsPage";
 import MyMinistryPage from "@/pages/my-ministry/MyMinistryPage";
 import MyProfilePage from "@/pages/my-profile/MyProfilePage";
+import PaymentPage from "@/pages/payment/PaymentPage";
 import RoomFilterPage from "@/pages/rooms/RoomFilterPage";
 import StartBookingPage from "@/pages/start-booking/StartBookingPage";
 import { createBrowserRouter } from "react-router";
@@ -33,6 +34,10 @@ export const router = createBrowserRouter([
           {
             path: "/booking-details",
             element: <BookingDetailsPage />,
+          },
+          {
+            path: "/payment/:bookingId",
+            element: <PaymentPage />,
           },
           {
             path: "/my-bookings",

--- a/src/utils/paymentPage.test.ts
+++ b/src/utils/paymentPage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatQuotedAmount, parsePaymentBookingId } from "./paymentPage";
+
+describe("parsePaymentBookingId", () => {
+  it("accepts a booking UUID", () => {
+    expect(parsePaymentBookingId("3fa85f64-5717-4562-b3fc-2c963f66afa6")).toBe("3fa85f64-5717-4562-b3fc-2c963f66afa6");
+  });
+
+  it("rejects a missing or non-UUID value", () => {
+    expect(parsePaymentBookingId(undefined)).toBe(null);
+    expect(parsePaymentBookingId("")).toBe(null);
+    expect(parsePaymentBookingId("not-a-uuid")).toBe(null);
+    expect(parsePaymentBookingId("date=2026-09-01&rooms=room-a")).toBe(null);
+  });
+});
+
+describe("formatQuotedAmount", () => {
+  it("shows an em dash when the GET has no quoted amount", () => {
+    expect(formatQuotedAmount(null, "CAD", "en")).toBe("—");
+    expect(formatQuotedAmount(undefined, "CAD", "en")).toBe("—");
+    expect(formatQuotedAmount("", "CAD", "en")).toBe("—");
+  });
+
+  it("formats the booker GET quoted amount", () => {
+    expect(formatQuotedAmount("85.00", "CAD", "en-CA")).toBe("$85.00");
+    expect(formatQuotedAmount(85, "CAD", "en-CA")).toBe("$85.00");
+  });
+});

--- a/src/utils/paymentPage.ts
+++ b/src/utils/paymentPage.ts
@@ -1,0 +1,33 @@
+const BOOKING_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const EM_DASH = "—";
+
+export const parsePaymentBookingId = (value: string | undefined): string | null => {
+  if (!value || !BOOKING_UUID.test(value)) {
+    return null;
+  }
+  return value;
+};
+
+export const formatQuotedAmount = (
+  quotedAmount: string | number | null | undefined,
+  currency: string | null | undefined,
+  locale: string
+): string => {
+  if (quotedAmount == null || quotedAmount === "") {
+    return EM_DASH;
+  }
+  const amount = typeof quotedAmount === "number" ? quotedAmount : Number(quotedAmount);
+  if (!Number.isFinite(amount)) {
+    return EM_DASH;
+  }
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: currency || "CAD",
+  }).format(amount);
+};
+
+export const isPaymentPath = (pathname: string): boolean => {
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.length === 2 && parts[0] === "payment" && parsePaymentBookingId(parts[1]) != null;
+};

--- a/src/utils/visitAccess.test.ts
+++ b/src/utils/visitAccess.test.ts
@@ -55,18 +55,41 @@ describe("visitAccess", () => {
     ).toBe("allow");
   });
 
-  it.each(["/", "/start-booking", "/contact", "/my-bookings", "/rooms", "/booking-details", "/my-profile"])(
-    "allows an authenticated member to open %s",
-    (pathname) => {
-      expect(
-        visitAccess({
-          isAuthenticated: true,
-          isMinistryMember: false,
-          pathname,
-        })
-      ).toBe("allow");
-    }
-  );
+  it.each([
+    "/",
+    "/start-booking",
+    "/contact",
+    "/my-bookings",
+    "/rooms",
+    "/booking-details",
+    "/my-profile",
+    "/payment/3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  ])("allows an authenticated member to open %s", (pathname) => {
+    expect(
+      visitAccess({
+        isAuthenticated: true,
+        isMinistryMember: false,
+        pathname,
+      })
+    ).toBe("allow");
+  });
+
+  it("shows Not Found for Payment without a booking UUID", () => {
+    expect(
+      visitAccess({
+        isAuthenticated: true,
+        isMinistryMember: false,
+        pathname: "/payment",
+      })
+    ).toBe("not-found");
+    expect(
+      visitAccess({
+        isAuthenticated: true,
+        isMinistryMember: false,
+        pathname: "/payment/not-a-uuid",
+      })
+    ).toBe("not-found");
+  });
 });
 
 describe("isMinistryMemberFromList", () => {

--- a/src/utils/visitAccess.ts
+++ b/src/utils/visitAccess.ts
@@ -1,3 +1,5 @@
+import { isPaymentPath } from "./paymentPage";
+
 export type VisitAccess = "login" | "not-found" | "allow";
 
 const LOGIN_PATH = "/login";
@@ -39,7 +41,7 @@ export const visitAccess = ({ isAuthenticated, isMinistryMember, pathname }: Vis
     return "allow";
   }
 
-  if (!KNOWN_MEMBER_PATHS.has(path)) {
+  if (!KNOWN_MEMBER_PATHS.has(path) && !isPaymentPath(path)) {
     return "not-found";
   }
 


### PR DESCRIPTION
## Summary

After a successful Confirm on Booking Details, navigate to Payment keyed by booking id. The page shows Canada Interac e-Transfer instructions, a placeholder email, and the booker GET quoted total (em dash when missing). There is no payment processor and no mark-as-paid action; the primary control is Back to Home.

Closes #23

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Create still holds the slot on Booking Details. Payment is `/payment/:bookingId` (not the draft room query). Unknown or non-UUID Payment paths stay Not Found, matching other member visits.

## Testing

- [x] `pnpm test`
- [x] `pnpm type-check`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)