### PR TITLE
feat: allowlist post-login next for ministry approval deep links

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,8 +37,40 @@ The page an authenticated member sees for an unknown path, or a path they are no
 _Avoid_: redirecting unknown paths to Home, 403 as the member-facing response, showing Not Found before login
 
 **My Ministry**:
-The member-facing place for a Ministry member to see the ministries they are listed on, including pending and rejected records.
-_Avoid_: the Start booking ministry picker, Support, Contact
+The member-facing place for a Ministry member to see the ministries they are listed on, including pending and rejected records. It has tabs for applications they submitted and, when they are an Owner-position incumbent, pending approvals waiting on them.
+_Avoid_: the approval queue as a separate top-level nav item, showing only active ministries
+
+**Application notification email**:
+An Outlook message sent from a fixed system mailbox to the Owner-position incumbent when a member submits a Ministry Application. It contains a deep link into the booking approval detail page. Body is bilingual: English first, then Chinese.
+_Avoid_: applicant confirmation as the same email, portal notification as this email, single-language-only templates in this slice
+
+**Application decision email**:
+An Outlook message to the applicant when a Ministry Application is approved or rejected. My Ministry also shows the updated status. Body is bilingual: English first, then Chinese.
+_Avoid_: treating this as the incumbent notification, in-app-only with no email
+
+**Application submit confirmation email**:
+An Outlook message to the applicant right after submit, summarizing the Ministry Application and linking to My Ministry. Body is bilingual: English first, then Chinese.
+_Avoid_: duplicating the incumbent notification, replacing My Ministry status updates
+
+**Target audience (application)**:
+Optional atomic catalog labels on booking create (multi-select). When present, `all_ages` cannot combine with other labels. Schedule is not collected on booking create.
+_Avoid_: merged poster phrases as one code, requiring audience for every ministry type
+
+**Ministry Application**:
+A Ministry in the pending-approval lifecycle after the member submits from booking. A Ministry Approver decides it; approving makes that Ministry Active so it can appear in Start booking / Search Bar Ministry.
+_Avoid_: Application as a synonym for an Active Ministry, treating Approval as the Application itself
+
+**Ministry Approver**:
+A person who may approve or reject a Ministry Application: the current incumbent of that Ministry's Owner position, or a user granted ministry approval authority in the admin portal.
+_Avoid_: incumbent-only as the sole rule, RBAC-only as the sole rule
+
+**Ministry approval queue**:
+The booking member view of Ministry Applications waiting on the signed-in user as Owner-position incumbent. Email links land on a detail page inside this queue after Microsoft sign-in.
+_Avoid_: the admin portal Approvals menu, treating the queue as My Ministry applications the user submitted
+
+**Steward picker search**:
+The booking create form finds secondary stewards among active auth users by email or display name (minimum query length, capped results). The applicant cannot select themselves as secondary.
+_Avoid_: invite-by-email without an existing auth user, searching Member Person records
 
 **Start booking**:
 The question flow after Home. Ministry choice: Yes goes to ministry name, No skips to One-time vs Repeated, then When, then Space needed. Search leaves this flow for the Timetable.

--- a/docs/adr/0019-my-ministry-application-and-approval-queue.md
+++ b/docs/adr/0019-my-ministry-application-and-approval-queue.md
@@ -1,0 +1,20 @@
+# My Ministry tabs unify applications and incumbent approval queue
+
+**My Ministry** is the single member surface for Ministry Application lifecycle: tab **My applications** (pending, rejected, active, resubmit) and tab **Pending my approval** (incumbent queue + detail). There is no separate top-level Approvals nav item.
+
+Incumbent notification emails deep-link to `/my-ministry/approvals/{ministryId}` after Microsoft sign-in. Post-login return uses an allowlisted `next` query (extends issue #39) so unauthenticated incumbents land on the detail page, not Home.
+
+Create Ministry collects ministry type, optional target audiences, and at least one secondary steward via member user search; schedule is not collected on booking create.
+
+## Considered Options
+
+- **Dedicated Approvals nav item when count > 0** — rejected: fragments My Ministry; CONTEXT treats approval queue as a tab.
+- **Portal-only incumbent approval** — rejected: product wants booking SPA decision UI and email entry point.
+- **Separate pending-only wizard step after create** — rejected: superseded by My Ministry + modal confirmation; QA wizard docs drift from modal flow.
+
+## Consequences
+
+- Routes under `/my-ministry` and `/my-ministry/approvals/:id`; TopNav keeps existing My Ministry entry (`ministryOnly` visibility unchanged in spirit).
+- Depends on core-api member approval APIs and Graph mail (ADR 0012 in `newlife-core-api`).
+- Depends on post-login `next` allowlist for approval paths (#39).
+- Expands scope of issue #2 beyond list-only stub.

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,10 +1,12 @@
-import { Navigate, Outlet } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 import { useAuth } from "@/context/AuthContext";
+import { buildLoginPathWithNext } from "@/utils/resolvePostLoginNext";
 import { useTranslation } from "react-i18next";
 
 const ProtectedRoute = () => {
   const { t } = useTranslation();
   const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
 
   if (isLoading) {
     return (
@@ -15,7 +17,8 @@ const ProtectedRoute = () => {
   }
 
   if (!isAuthenticated) {
-    return <Navigate replace to="/login" />;
+    const returnPath = `${location.pathname}${location.search}`;
+    return <Navigate replace to={buildLoginPathWithNext(returnPath)} />;
   }
 
   return <Outlet />;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -6,14 +6,17 @@ import { useAuth } from "@/context/AuthContext";
 import { Checkbox, cn, Input } from "@efcnewlife/newlife-ui";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { resolvePostLoginNext } from "@/utils/resolvePostLoginNext";
+import { useNavigate, useSearchParams } from "react-router";
 
 const LoginPage = () => {
   const { t } = useTranslation();
   const [rememberMe, setRememberMe] = useState(false);
   const [devEmail, setDevEmail] = useState(ENV_CONFIG.DEV_LOGIN_EMAIL);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { loginWithMicrosoft, loginAsDevUser, isLoading, error, isAuthenticated, clearError } = useAuth();
+  const postLoginPath = resolvePostLoginNext(searchParams.get("next"));
 
   const isDevEmailValid = useMemo(() => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -22,15 +25,15 @@ const LoginPage = () => {
 
   useEffect(() => {
     if (isAuthenticated) {
-      navigate("/", { replace: true });
+      navigate(postLoginPath, { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, navigate, postLoginPath]);
 
   const handleMicrosoftSignIn = async () => {
     clearError();
     try {
       await loginWithMicrosoft(rememberMe);
-      navigate("/", { replace: true });
+      navigate(postLoginPath, { replace: true });
     } catch (signInError) {
       console.error(signInError);
     }
@@ -41,7 +44,7 @@ const LoginPage = () => {
     clearError();
     try {
       await loginAsDevUser({ email: devEmail, rememberMe });
-      navigate("/", { replace: true });
+      navigate(postLoginPath, { replace: true });
     } catch (signInError) {
       console.error(signInError);
     }

--- a/src/utils/resolvePostLoginNext.test.ts
+++ b/src/utils/resolvePostLoginNext.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildLoginPathWithNext, isAllowlistedPostLoginPath, resolvePostLoginNext } from "./resolvePostLoginNext";
+
+const MINISTRY_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+
+describe("isAllowlistedPostLoginPath", () => {
+  it("allows ministry approval detail paths", () => {
+    expect(isAllowlistedPostLoginPath(`/my-ministry/approvals/${MINISTRY_ID}`)).toBe(true);
+  });
+
+  it("rejects the approvals index without a ministry id", () => {
+    expect(isAllowlistedPostLoginPath("/my-ministry/approvals")).toBe(false);
+    expect(isAllowlistedPostLoginPath("/my-ministry/approvals/")).toBe(false);
+  });
+
+  it("rejects nested paths under approvals", () => {
+    expect(isAllowlistedPostLoginPath(`/my-ministry/approvals/${MINISTRY_ID}/edit`)).toBe(false);
+  });
+
+  it("rejects non-uuid ministry ids", () => {
+    expect(isAllowlistedPostLoginPath("/my-ministry/approvals/not-a-uuid")).toBe(false);
+  });
+
+  it("rejects unrelated member paths", () => {
+    expect(isAllowlistedPostLoginPath("/my-ministry")).toBe(false);
+    expect(isAllowlistedPostLoginPath("/")).toBe(false);
+    expect(isAllowlistedPostLoginPath("/contact")).toBe(false);
+  });
+});
+
+describe("resolvePostLoginNext", () => {
+  it("returns the allowlisted path when next is valid", () => {
+    const path = `/my-ministry/approvals/${MINISTRY_ID}`;
+    expect(resolvePostLoginNext(path)).toBe(path);
+    expect(resolvePostLoginNext(encodeURIComponent(path))).toBe(path);
+  });
+
+  it("returns home when next is missing or empty", () => {
+    expect(resolvePostLoginNext(null)).toBe("/");
+    expect(resolvePostLoginNext(undefined)).toBe("/");
+    expect(resolvePostLoginNext("")).toBe("/");
+  });
+
+  it("rejects open redirects", () => {
+    expect(resolvePostLoginNext("https://evil.example/phish")).toBe("/");
+    expect(resolvePostLoginNext("//evil.example/phish")).toBe("/");
+    expect(resolvePostLoginNext("/\\evil.example/phish")).toBe("/");
+    expect(resolvePostLoginNext("javascript:alert(1)")).toBe("/");
+  });
+
+  it("rejects paths outside the allowlist", () => {
+    expect(resolvePostLoginNext("/my-bookings")).toBe("/");
+    expect(resolvePostLoginNext("/login")).toBe("/");
+  });
+
+  it("preserves an allowlisted search string", () => {
+    const path = `/my-ministry/approvals/${MINISTRY_ID}?tab=pending`;
+    expect(resolvePostLoginNext(path)).toBe(path);
+  });
+
+  it("normalizes trailing slashes on the pathname", () => {
+    expect(resolvePostLoginNext(`/my-ministry/approvals/${MINISTRY_ID}/`)).toBe(
+      `/my-ministry/approvals/${MINISTRY_ID}`
+    );
+  });
+});
+
+describe("buildLoginPathWithNext", () => {
+  it("encodes the return path in the next query param", () => {
+    const returnPath = `/my-ministry/approvals/${MINISTRY_ID}?tab=pending`;
+    expect(buildLoginPathWithNext(returnPath)).toBe(`/login?next=${encodeURIComponent(returnPath)}`);
+  });
+});

--- a/src/utils/resolvePostLoginNext.ts
+++ b/src/utils/resolvePostLoginNext.ts
@@ -1,0 +1,79 @@
+const BOOKING_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MINISTRY_APPROVAL_PREFIX = "/my-ministry/approvals/";
+const HOME_PATH = "/";
+
+const normalizePathname = (pathname: string): string => {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+};
+
+const splitPathAndSearch = (value: string): { pathname: string; search: string } => {
+  const queryIndex = value.indexOf("?");
+  if (queryIndex === -1) {
+    return { pathname: value, search: "" };
+  }
+
+  return {
+    pathname: value.slice(0, queryIndex),
+    search: value.slice(queryIndex),
+  };
+};
+
+const decodeNextParam = (next: string): string | null => {
+  try {
+    return decodeURIComponent(next);
+  } catch {
+    return null;
+  }
+};
+
+const isSafeRelativePath = (value: string): boolean => {
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    return false;
+  }
+
+  if (value.includes("://") || value.includes("\\")) {
+    return false;
+  }
+
+  return true;
+};
+
+export const isAllowlistedPostLoginPath = (pathname: string): boolean => {
+  const path = normalizePathname(pathname);
+  if (!path.startsWith(MINISTRY_APPROVAL_PREFIX)) {
+    return false;
+  }
+
+  const ministryId = path.slice(MINISTRY_APPROVAL_PREFIX.length);
+  if (!ministryId || ministryId.includes("/")) {
+    return false;
+  }
+
+  return BOOKING_UUID.test(ministryId);
+};
+
+export const resolvePostLoginNext = (next: string | null | undefined): string => {
+  if (!next) {
+    return HOME_PATH;
+  }
+
+  const decoded = decodeNextParam(next);
+  if (!decoded || !isSafeRelativePath(decoded)) {
+    return HOME_PATH;
+  }
+
+  const { pathname, search } = splitPathAndSearch(decoded);
+  const normalizedPathname = normalizePathname(pathname);
+  if (!isAllowlistedPostLoginPath(normalizedPathname)) {
+    return HOME_PATH;
+  }
+
+  return `${normalizedPathname}${search}`;
+};
+
+export const buildLoginPathWithNext = (returnPath: string): string => {
+  return `/login?next=${encodeURIComponent(returnPath)}`;
+};


### PR DESCRIPTION
## Summary

- Add `resolvePostLoginNext` helper that allowlists `/my-ministry/approvals/{uuid}` paths and rejects open redirects.
- Redirect unauthenticated protected-route visits to `/login?next=<encoded path>`.
- After successful Microsoft or dev login, navigate to the allowlisted `next` path when present; otherwise fall back to Home.
- Document My Ministry approval queue vocabulary in `CONTEXT.md` and ADR 0019.

Closes #44

## Test plan

- [x] `pnpm test`
- [x] `pnpm type-check`
- [ ] Unauthenticated visit to `/my-ministry/approvals/{id}` redirects to login with `next` query
- [ ] Successful login with valid `next` lands on the approval detail path
- [ ] Invalid or missing `next` still lands on Home after login


Made with [Cursor](https://cursor.com)