### PR TITLE
feat: My Ministry applications tab, list, and resubmit (#46)

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -12,6 +12,9 @@ export const API_ENDPOINTS = {
   MINISTRY: {
     MINE: `${BOOKING_API_PREFIX}/ministry/ministries/mine`,
     APPLICATIONS: `${BOOKING_API_PREFIX}/ministry/applications`,
+    APPLICATION: (ministryId: string) => `${BOOKING_API_PREFIX}/ministry/applications/${ministryId}`,
+    RESUBMIT_APPLICATION: (ministryId: string) => `${BOOKING_API_PREFIX}/ministry/applications/${ministryId}/submit`,
+    APPLICATION_DETAIL: (ministryId: string) => `${BOOKING_API_PREFIX}/ministry/approvals/${ministryId}`,
     MINISTRY_TYPES: `${BOOKING_API_PREFIX}/ministry/catalog/ministry-types`,
     TARGET_AUDIENCES: `${BOOKING_API_PREFIX}/ministry/catalog/target-audiences`,
   },

--- a/src/api/services/httpClient.ts
+++ b/src/api/services/httpClient.ts
@@ -206,6 +206,10 @@ class HttpClient {
     return this.request<T>({ method: "POST", url, data });
   }
 
+  async put<T = unknown>(url: string, data?: unknown): Promise<ApiResponse<T>> {
+    return this.request<T>({ method: "PUT", url, data });
+  }
+
   private isRefreshRequest(config: AxiosRequestConfig): boolean {
     const url = typeof config.url === "string" ? config.url : "";
     return url === API_ENDPOINTS.AUTH.REFRESH;

--- a/src/api/services/ministryService.ts
+++ b/src/api/services/ministryService.ts
@@ -6,8 +6,10 @@ import type {
   LocaleItem,
   LocaleListResponse,
   MinistryCatalogListResponse,
+  MinistryDetail,
   MinistryListResponse,
   OrgUserSearchListResponse,
+  UpdateMinistryApplicationPayload,
 } from "@/types/ministry";
 import { httpClient } from "./httpClient";
 
@@ -97,6 +99,40 @@ class MinistryService {
         throw error;
       }
       throw error instanceof Error ? error : new Error("Failed to create ministry application");
+    }
+  }
+
+  async getApplicationDetail(ministryId: string): Promise<MinistryDetail> {
+    const response = await httpClient.get<MinistryDetail>(API_ENDPOINTS.MINISTRY.APPLICATION_DETAIL(ministryId));
+    if (!response.success || !response.data) {
+      throw new Error(response.message || "Failed to load ministry application");
+    }
+    return {
+      ...response.data,
+      translations: response.data.translations || [],
+      members: response.data.members || [],
+      targetAudiences: response.data.targetAudiences || [],
+    };
+  }
+
+  async updateRejectedApplication(ministryId: string, payload: UpdateMinistryApplicationPayload): Promise<void> {
+    try {
+      const response = await httpClient.put<void>(API_ENDPOINTS.MINISTRY.APPLICATION(ministryId), payload);
+      if (!response.success) {
+        throw new Error(response.message || "Failed to update ministry application");
+      }
+    } catch (error) {
+      if (isApiError(error)) {
+        throw error;
+      }
+      throw error instanceof Error ? error : new Error("Failed to update ministry application");
+    }
+  }
+
+  async resubmitApplication(ministryId: string): Promise<void> {
+    const response = await httpClient.post<void>(API_ENDPOINTS.MINISTRY.RESUBMIT_APPLICATION(ministryId));
+    if (!response.success) {
+      throw new Error(response.message || "Failed to resubmit ministry application");
     }
   }
 }

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -46,7 +46,39 @@
     }
   },
   "myMinistry": {
-    "pageTitle": "My Ministry"
+    "pageTitle": "My Ministry",
+    "tabs": {
+      "ariaLabel": "My Ministry sections",
+      "applications": "My applications",
+      "approvals": "Pending my approval"
+    },
+    "applications": {
+      "empty": "You do not have any ministry applications yet.",
+      "unnamed": "Untitled ministry",
+      "ministryType": "Type: {{type}}",
+      "rejectionReason": "Rejection reason",
+      "startBooking": "Start booking",
+      "status": {
+        "pendingApproval": "Pending approval",
+        "rejected": "Rejected",
+        "active": "Active",
+        "unknown": "Unknown"
+      },
+      "resubmit": {
+        "action": "Edit and resubmit",
+        "title": "Resubmit ministry application",
+        "submit": "Resubmit application"
+      },
+      "errors": {
+        "title": "Unable to load applications",
+        "loadList": "Failed to load your ministry applications.",
+        "loadResubmit": "Failed to load the application for editing.",
+        "resubmit": "Failed to resubmit the ministry application."
+      }
+    },
+    "approvals": {
+      "comingSoon": "Pending approvals for your owner positions will appear here."
+    }
   },
   "notFound": {
     "title": "Page not found",

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -46,7 +46,39 @@
     }
   },
   "myMinistry": {
-    "pageTitle": "我的事工"
+    "pageTitle": "我的事工",
+    "tabs": {
+      "ariaLabel": "我的事工区块",
+      "applications": "我的申请",
+      "approvals": "待我审核"
+    },
+    "applications": {
+      "empty": "您目前还没有事工申请。",
+      "unnamed": "未命名事工",
+      "ministryType": "类型：{{type}}",
+      "rejectionReason": "拒绝原因",
+      "startBooking": "开始预订",
+      "status": {
+        "pendingApproval": "待审核",
+        "rejected": "已拒绝",
+        "active": "已启用",
+        "unknown": "未知"
+      },
+      "resubmit": {
+        "action": "编辑并重新提交",
+        "title": "重新提交事工申请",
+        "submit": "重新提交申请"
+      },
+      "errors": {
+        "title": "无法加载申请",
+        "loadList": "无法加载您的事工申请。",
+        "loadResubmit": "无法加载要编辑的申请。",
+        "resubmit": "重新提交事工申请失败。"
+      }
+    },
+    "approvals": {
+      "comingSoon": "您担任负责职位时，待审核的申请会显示在这里。"
+    }
   },
   "notFound": {
     "title": "找不到页面",

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -46,7 +46,39 @@
     }
   },
   "myMinistry": {
-    "pageTitle": "我的事工"
+    "pageTitle": "我的事工",
+    "tabs": {
+      "ariaLabel": "我的事工區塊",
+      "applications": "我的申請",
+      "approvals": "待我審核"
+    },
+    "applications": {
+      "empty": "您目前還沒有事工申請。",
+      "unnamed": "未命名事工",
+      "ministryType": "類型：{{type}}",
+      "rejectionReason": "拒絕原因",
+      "startBooking": "開始預訂",
+      "status": {
+        "pendingApproval": "待審核",
+        "rejected": "已拒絕",
+        "active": "已啟用",
+        "unknown": "未知"
+      },
+      "resubmit": {
+        "action": "編輯並重新提交",
+        "title": "重新提交事工申請",
+        "submit": "重新提交申請"
+      },
+      "errors": {
+        "title": "無法載入申請",
+        "loadList": "無法載入您的事工申請。",
+        "loadResubmit": "無法載入要編輯的申請。",
+        "resubmit": "重新提交事工申請失敗。"
+      }
+    },
+    "approvals": {
+      "comingSoon": "您擔任負責職位時，待審核的申請會顯示在這裡。"
+    }
   },
   "notFound": {
     "title": "找不到頁面",

--- a/src/pages/my-ministry/MyApplicationsTab.tsx
+++ b/src/pages/my-ministry/MyApplicationsTab.tsx
@@ -1,0 +1,173 @@
+import ministryService from "@/api/services/ministryService";
+import ResubmitMinistryModal from "@/pages/my-ministry/ResubmitMinistryModal";
+import { useAuth } from "@/context/AuthContext";
+import type { MinistryItem } from "@/types/ministry";
+import {
+  getMinistryStatusBadgeColor,
+  isActiveMinistryStatus,
+  isRejectedMinistryStatus,
+  MINISTRY_STATUS,
+} from "@/utils/ministryStatus";
+import { Alert, Badge, Button, Spinner } from "@efcnewlife/newlife-ui";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+
+const START_BOOKING_PATH = "/start-booking?step=select_ministry&ministry=1";
+
+const statusLabelKey = (status: string): string => {
+  switch (status) {
+    case MINISTRY_STATUS.PENDING_APPROVAL:
+      return "myMinistry.applications.status.pendingApproval";
+    case MINISTRY_STATUS.REJECTED:
+      return "myMinistry.applications.status.rejected";
+    case MINISTRY_STATUS.ACTIVE:
+      return "myMinistry.applications.status.active";
+    default:
+      return "myMinistry.applications.status.unknown";
+  }
+};
+
+const enrichRejectedApplications = async (items: MinistryItem[]): Promise<MinistryItem[]> => {
+  const rejectedIds = items.filter((item) => isRejectedMinistryStatus(item.status)).map((item) => item.id);
+  if (rejectedIds.length === 0) {
+    return items;
+  }
+
+  const details = await Promise.all(
+    rejectedIds.map(async (id) => {
+      try {
+        return await ministryService.getApplicationDetail(id);
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  const rejectionReasonById = new Map<string, string | null | undefined>();
+  details.forEach((detail) => {
+    if (detail) {
+      rejectionReasonById.set(detail.id, detail.rejectionReason);
+    }
+  });
+
+  return items.map((item) =>
+    rejectionReasonById.has(item.id)
+      ? {
+          ...item,
+          rejectionReason: rejectionReasonById.get(item.id) ?? null,
+        }
+      : item
+  );
+};
+
+const MyApplicationsTab = () => {
+  const { t } = useTranslation("booking");
+  const { user } = useAuth();
+  const [applications, setApplications] = useState<MinistryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resubmitMinistryId, setResubmitMinistryId] = useState<string | null>(null);
+
+  const loadApplications = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await ministryService.listMine(true);
+      const items = await enrichRejectedApplications(result.items || []);
+      setApplications(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("myMinistry.applications.errors.loadList"));
+      setApplications([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    void loadApplications();
+  }, [loadApplications]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <Alert message={error} title={t("myMinistry.applications.errors.title")} variant="error" width="full" />;
+  }
+
+  if (applications.length === 0) {
+    return <p className="text-sm font-medium text-on-surface-variant">{t("myMinistry.applications.empty")}</p>;
+  }
+
+  return (
+    <>
+      <ul className="space-y-4">
+        {applications.map((application) => {
+          const statusColor = getMinistryStatusBadgeColor(application.status);
+          const ministryTypeLabel = application.ministryType?.name || application.ministryType?.code;
+
+          return (
+            <li key={application.id} className="rounded-xl border border-outline-variant bg-surface p-4 sm:p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 space-y-1">
+                  <h3 className="text-lg font-semibold text-on-surface">
+                    {application.name?.trim() || t("myMinistry.applications.unnamed")}
+                  </h3>
+                  {ministryTypeLabel ? (
+                    <p className="text-sm text-on-surface-variant">
+                      {t("myMinistry.applications.ministryType", { type: ministryTypeLabel })}
+                    </p>
+                  ) : null}
+                </div>
+                <Badge color={statusColor} variant="light">
+                  {t(statusLabelKey(application.status))}
+                </Badge>
+              </div>
+
+              {isRejectedMinistryStatus(application.status) && application.rejectionReason ? (
+                <div className="mt-3 rounded-lg bg-error-container/40 px-3 py-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-error">
+                    {t("myMinistry.applications.rejectionReason")}
+                  </p>
+                  <p className="mt-1 text-sm text-on-surface">{application.rejectionReason}</p>
+                </div>
+              ) : null}
+
+              <div className="mt-4 flex flex-wrap gap-3">
+                {isRejectedMinistryStatus(application.status) ? (
+                  <Button onClick={() => setResubmitMinistryId(application.id)} size="sm" variant="primary">
+                    {t("myMinistry.applications.resubmit.action")}
+                  </Button>
+                ) : null}
+                {isActiveMinistryStatus(application.status, application.isActive) ? (
+                  <Link to={START_BOOKING_PATH}>
+                    <Button size="sm" variant="outline">
+                      {t("myMinistry.applications.startBooking")}
+                    </Button>
+                  </Link>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <ResubmitMinistryModal
+        isOpen={Boolean(resubmitMinistryId)}
+        ministryId={resubmitMinistryId}
+        onClose={() => setResubmitMinistryId(null)}
+        onResubmitted={() => {
+          void loadApplications();
+        }}
+        userId={user?.id}
+      />
+    </>
+  );
+};
+
+export default MyApplicationsTab;

--- a/src/pages/my-ministry/MyMinistryPage.tsx
+++ b/src/pages/my-ministry/MyMinistryPage.tsx
@@ -1,11 +1,37 @@
+import MyApplicationsTab from "@/pages/my-ministry/MyApplicationsTab";
+import { Tabs } from "@efcnewlife/newlife-ui";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+
+type MyMinistryTab = "applications" | "approvals";
 
 const MyMinistryPage = () => {
   const { t } = useTranslation("booking");
+  const [activeTab, setActiveTab] = useState<MyMinistryTab>("applications");
 
   return (
     <main className="mx-auto w-full max-w-[960px] flex-1 px-4 py-7 sm:px-6 lg:px-8">
       <h1 className="text-center text-2xl font-bold text-on-surface">{t("myMinistry.pageTitle")}</h1>
+
+      <div className="mt-8">
+        <Tabs
+          aria-label={t("myMinistry.tabs.ariaLabel")}
+          onChange={(value) => setActiveTab(value as MyMinistryTab)}
+          tabs={[
+            { value: "applications", label: t("myMinistry.tabs.applications") },
+            { value: "approvals", label: t("myMinistry.tabs.approvals") },
+          ]}
+          value={activeTab}
+        />
+
+        <div className="mt-6" role="tabpanel">
+          {activeTab === "applications" ? (
+            <MyApplicationsTab />
+          ) : (
+            <p className="text-sm font-medium text-on-surface-variant">{t("myMinistry.approvals.comingSoon")}</p>
+          )}
+        </div>
+      </div>
     </main>
   );
 };

--- a/src/pages/my-ministry/ResubmitMinistryModal.tsx
+++ b/src/pages/my-ministry/ResubmitMinistryModal.tsx
@@ -1,0 +1,398 @@
+import ministryService from "@/api/services/ministryService";
+import i18n from "@/i18n";
+import type {
+  AssignablePosition,
+  LocaleItem,
+  MinistryCatalogItem,
+  MinistryDetail,
+  OrgUserSearchItem,
+} from "@/types/ministry";
+import {
+  applyTargetAudienceSelection,
+  canSelectSecondarySteward,
+  shouldSearchSecondaryStewards,
+  validateCreateMinistryForm,
+  type CreateMinistryValidationKey,
+} from "@/utils/createMinistryForm";
+import { resolveMinistryApplicationErrorMessage } from "@/utils/ministryApplicationErrors";
+import { Alert, Button, ComboBox, Input, ModalForm, Select, type ModalFormHandle } from "@efcnewlife/newlife-ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface ResubmitMinistryModalProps {
+  ministryId: string | null;
+  userId?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onResubmitted: () => void;
+}
+
+const resolveLocaleId = (locales: LocaleItem[]): string => {
+  const lang = (i18n.language || "en").toLowerCase();
+  const match =
+    locales.find((item) => {
+      const code = `${item.languageCode || ""}${item.regionCode ? `-${item.regionCode}` : ""}`.toLowerCase();
+      return code === lang || code.startsWith(lang.split("-")[0]);
+    }) ||
+    locales.find((item) => item.isDefault) ||
+    locales[0];
+  return match?.id || "";
+};
+
+const formatUserLabel = (item: OrgUserSearchItem): string => {
+  const name = item.displayName?.trim();
+  const email = item.email?.trim();
+  if (name && email) {
+    return `${name} (${email})`;
+  }
+  return name || email || item.id;
+};
+
+const resolveTranslationForLocale = (
+  translations: MinistryDetail["translations"],
+  localeId: string
+): { name: string; description: string } => {
+  const match = translations.find((item) => item.localeId === localeId) || translations[0];
+  return {
+    name: match?.name?.trim() || "",
+    description: match?.description?.trim() || "",
+  };
+};
+
+const ResubmitMinistryModal = ({ ministryId, userId, isOpen, onClose, onResubmitted }: ResubmitMinistryModalProps) => {
+  const { t } = useTranslation("booking");
+  const modalRef = useRef<ModalFormHandle>(null);
+  const [positions, setPositions] = useState<AssignablePosition[]>([]);
+  const [locales, setLocales] = useState<LocaleItem[]>([]);
+  const [ministryTypes, setMinistryTypes] = useState<MinistryCatalogItem[]>([]);
+  const [targetAudiences, setTargetAudiences] = useState<MinistryCatalogItem[]>([]);
+  const [ministryName, setMinistryName] = useState("");
+  const [ministryTypeId, setMinistryTypeId] = useState("");
+  const [ownerPositionId, setOwnerPositionId] = useState("");
+  const [purpose, setPurpose] = useState("");
+  const [targetAudienceIds, setTargetAudienceIds] = useState<string[]>([]);
+  const [secondaryStewardIds, setSecondaryStewardIds] = useState<string[]>([]);
+  const [stewardUsersById, setStewardUsersById] = useState<Record<string, OrgUserSearchItem>>({});
+  const [stewardSearchQuery, setStewardSearchQuery] = useState("");
+  const [stewardSearchLoading, setStewardSearchLoading] = useState(false);
+  const [stewardSearchResults, setStewardSearchResults] = useState<OrgUserSearchItem[]>([]);
+  const [hasPriorityBooking, setHasPriorityBooking] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const defaultLocaleId = useMemo(() => resolveLocaleId(locales), [locales]);
+
+  const resetForm = useCallback(() => {
+    setMinistryName("");
+    setMinistryTypeId("");
+    setOwnerPositionId("");
+    setPurpose("");
+    setTargetAudienceIds([]);
+    setSecondaryStewardIds([]);
+    setStewardUsersById({});
+    setStewardSearchQuery("");
+    setStewardSearchResults([]);
+    setError(null);
+  }, []);
+
+  const applyDetailToForm = useCallback((detail: MinistryDetail, localeId: string) => {
+    const translation = resolveTranslationForLocale(detail.translations, localeId);
+    setMinistryName(translation.name);
+    setPurpose(translation.description);
+    setMinistryTypeId(detail.ministryTypeId || detail.ministryType?.id || "");
+    setOwnerPositionId(detail.ownerPositionId || "");
+    setTargetAudienceIds((detail.targetAudiences || []).map((item) => item.id));
+    setHasPriorityBooking(detail.hasPriorityBooking ?? true);
+
+    const secondaryIds = (detail.members || [])
+      .filter((member) => member.memberRole === "secondary")
+      .map((member) => member.userId);
+    setSecondaryStewardIds(secondaryIds);
+
+    const stewardsById: Record<string, OrgUserSearchItem> = {};
+    (detail.members || []).forEach((member) => {
+      if (member.memberRole === "secondary") {
+        stewardsById[member.userId] = {
+          id: member.userId,
+          email: member.email,
+          displayName: member.displayName,
+        };
+      }
+    });
+    setStewardUsersById(stewardsById);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || !ministryId) {
+      return;
+    }
+
+    resetForm();
+    const loadForm = async () => {
+      setLoading(true);
+      try {
+        const [detail, positionResult, localeResult, ministryTypeResult, targetAudienceResult] = await Promise.all([
+          ministryService.getApplicationDetail(ministryId),
+          ministryService.listAssignablePositions(),
+          ministryService.listLocales(),
+          ministryService.listMinistryTypes(),
+          ministryService.listTargetAudiences(),
+        ]);
+        setPositions(positionResult.items || []);
+        setLocales(localeResult.items || []);
+        setMinistryTypes(ministryTypeResult.items || []);
+        setTargetAudiences(targetAudienceResult.items || []);
+        const localeId = resolveLocaleId(localeResult.items || []);
+        applyDetailToForm(detail, localeId);
+      } catch (err) {
+        setError(resolveMinistryApplicationErrorMessage(err, "myMinistry.applications.errors.loadResubmit"));
+      } finally {
+        setLoading(false);
+      }
+    };
+    void loadForm();
+  }, [applyDetailToForm, isOpen, ministryId, resetForm]);
+
+  useEffect(() => {
+    if (!shouldSearchSecondaryStewards(stewardSearchQuery)) {
+      setStewardSearchResults([]);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void (async () => {
+        setStewardSearchLoading(true);
+        try {
+          const result = await ministryService.searchUsers(stewardSearchQuery.trim());
+          const filtered = (result.items || []).filter((item) => canSelectSecondarySteward(item.id, userId));
+          setStewardSearchResults(filtered);
+          setStewardUsersById((current) => {
+            const next = { ...current };
+            filtered.forEach((item) => {
+              next[item.id] = item;
+            });
+            return next;
+          });
+        } catch {
+          setStewardSearchResults([]);
+        } finally {
+          setStewardSearchLoading(false);
+        }
+      })();
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [stewardSearchQuery, userId]);
+
+  const stewardComboBoxOptions = useMemo(() => {
+    const merged = new Map<string, OrgUserSearchItem>();
+    secondaryStewardIds.forEach((id) => {
+      const existing = stewardUsersById[id];
+      if (existing) {
+        merged.set(id, existing);
+      }
+    });
+    stewardSearchResults.forEach((item) => {
+      merged.set(item.id, item);
+    });
+    return Array.from(merged.values()).map((item) => ({
+      value: item.id,
+      label: formatUserLabel(item),
+    }));
+  }, [secondaryStewardIds, stewardSearchResults, stewardUsersById]);
+
+  const ownerPositionLabel = useMemo(() => {
+    const position = positions.find((item) => item.id === ownerPositionId);
+    if (!position) {
+      return ownerPositionId;
+    }
+    const name = position.name || position.code || position.id;
+    const officeKey = position.office?.toLowerCase();
+    const officeLabel = officeKey
+      ? t(`startBooking.createMinistry.office.${officeKey}`, {
+          defaultValue: position.office || "",
+        })
+      : "";
+    return officeLabel ? `${name} (${officeLabel})` : name;
+  }, [ownerPositionId, positions, t]);
+
+  const validationMessage = (key: CreateMinistryValidationKey): string => t(`startBooking.errors.${key}`);
+
+  const handleSubmit = async () => {
+    if (!ministryId) {
+      return;
+    }
+
+    const validationKey = validateCreateMinistryForm(
+      {
+        ministryName,
+        ministryTypeId,
+        ownerPositionId,
+        purpose,
+        localeId: defaultLocaleId,
+        targetAudienceIds,
+        secondaryStewardIds,
+      },
+      targetAudiences,
+      userId
+    );
+    if (validationKey) {
+      setError(validationMessage(validationKey));
+      return;
+    }
+
+    if (!userId) {
+      setError(validationMessage("createMinistryValidation"));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      await ministryService.updateRejectedApplication(ministryId, {
+        ministryTypeId,
+        targetAudienceIds,
+        hasPriorityBooking,
+        translations: [
+          {
+            localeId: defaultLocaleId,
+            name: ministryName.trim(),
+            description: purpose.trim(),
+          },
+        ],
+        members: [
+          {
+            userId,
+            memberRole: "primary",
+          },
+          ...secondaryStewardIds.map((stewardUserId) => ({
+            userId: stewardUserId,
+            memberRole: "secondary" as const,
+          })),
+        ],
+      });
+      await ministryService.resubmitApplication(ministryId);
+      onResubmitted();
+      onClose();
+    } catch (err) {
+      setError(resolveMinistryApplicationErrorMessage(err, "myMinistry.applications.errors.resubmit"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ModalForm
+      className="max-w-2xl w-full mx-4 p-6"
+      footer={
+        <>
+          <Button onClick={onClose} size="sm" variant="outline">
+            {t("startBooking.back")}
+          </Button>
+          <Button disabled={loading} onClick={() => modalRef.current?.submit()} size="sm" variant="primary">
+            {t("myMinistry.applications.resubmit.submit")}
+          </Button>
+        </>
+      }
+      isOpen={isOpen}
+      onClose={onClose}
+      onSubmit={async (event) => {
+        event.preventDefault();
+        await handleSubmit();
+      }}
+      ref={modalRef}
+      title={t("myMinistry.applications.resubmit.title")}
+    >
+      <div className="space-y-4">
+        {error ? <Alert message={error} title={t("startBooking.errors.title")} variant="error" width="full" /> : null}
+        <Input
+          disabled
+          id="resubmit-ministry-owner"
+          label={t("startBooking.createMinistry.ownerPosition")}
+          value={ownerPositionLabel}
+        />
+        <Input
+          id="resubmit-ministry-name"
+          label={t("startBooking.createMinistry.name")}
+          onChange={(event) => setMinistryName(event.target.value)}
+          placeholder={t("startBooking.createMinistry.namePlaceholder")}
+          required
+          value={ministryName}
+        />
+        <Select
+          id="resubmit-ministry-type"
+          label={t("startBooking.createMinistry.ministryType")}
+          labels={{
+            noOptions: t("startBooking.createMinistry.ministryTypeEmpty"),
+            searchOptions: t("startBooking.createMinistry.ministryTypeSearch"),
+          }}
+          onChange={(value) => {
+            setMinistryTypeId(typeof value === "string" ? value : "");
+          }}
+          options={ministryTypes.map((item) => ({
+            value: item.id,
+            label: item.name || item.code,
+          }))}
+          placeholder={t("startBooking.createMinistry.ministryTypePlaceholder")}
+          required
+          searchable
+          value={ministryTypeId || null}
+        />
+        <ComboBox<string>
+          filterFunction={() => true}
+          id="resubmit-ministry-target-audiences"
+          label={t("startBooking.createMinistry.targetAudiences")}
+          hint={t("startBooking.createMinistry.targetAudiencesHint")}
+          multiple
+          onChange={(value) => {
+            const nextIds = value ?? [];
+            const added = nextIds.find((id) => !targetAudienceIds.includes(id));
+            const removed = targetAudienceIds.find((id) => !nextIds.includes(id));
+            if (added) {
+              setTargetAudienceIds(applyTargetAudienceSelection(targetAudienceIds, added, targetAudiences, true));
+              return;
+            }
+            if (removed) {
+              setTargetAudienceIds(applyTargetAudienceSelection(targetAudienceIds, removed, targetAudiences, false));
+              return;
+            }
+            setTargetAudienceIds(nextIds);
+          }}
+          options={targetAudiences.map((item) => ({
+            value: item.id,
+            label: item.name || item.code,
+          }))}
+          placeholder={t("startBooking.createMinistry.targetAudiencesPlaceholder")}
+          value={targetAudienceIds}
+        />
+        <ComboBox<string>
+          filterFunction={() => true}
+          hint={t("startBooking.createMinistry.secondaryStewardsSearchHint")}
+          id="resubmit-ministry-secondary-stewards"
+          label={t("startBooking.createMinistry.secondaryStewards")}
+          loading={stewardSearchLoading}
+          multiple
+          onChange={(value) => {
+            const nextIds = (value ?? []).filter((id) => canSelectSecondarySteward(id, userId));
+            setSecondaryStewardIds(nextIds);
+          }}
+          onQueryChange={setStewardSearchQuery}
+          options={stewardComboBoxOptions}
+          placeholder={t("startBooking.createMinistry.secondaryStewardsPlaceholder")}
+          required
+          value={secondaryStewardIds}
+        />
+        <Input
+          id="resubmit-ministry-purpose"
+          label={t("startBooking.createMinistry.purpose")}
+          onChange={(event) => setPurpose(event.target.value)}
+          placeholder={t("startBooking.createMinistry.purposePlaceholder")}
+          required
+          value={purpose}
+        />
+      </div>
+    </ModalForm>
+  );
+};
+
+export default ResubmitMinistryModal;

--- a/src/types/ministry.ts
+++ b/src/types/ministry.ts
@@ -1,9 +1,40 @@
+export interface MinistryCatalogRef {
+  id: string;
+  code: string;
+  name?: string | null;
+}
+
 export interface MinistryItem {
   id: string;
   name?: string | null;
   status: string;
   hasPriorityBooking?: boolean;
   isActive?: boolean;
+  ministryType?: MinistryCatalogRef | null;
+  targetAudiences?: MinistryCatalogRef[];
+  rejectionReason?: string | null;
+}
+
+export interface MinistryTranslation {
+  localeId: string;
+  name: string;
+  description?: string | null;
+  remark?: string | null;
+  scheduleNote?: string | null;
+}
+
+export interface MinistryMember {
+  userId: string;
+  memberRole: string;
+  email?: string | null;
+  displayName?: string | null;
+}
+
+export interface MinistryDetail extends MinistryItem {
+  ownerPositionId?: string | null;
+  ministryTypeId?: string | null;
+  translations: MinistryTranslation[];
+  members: MinistryMember[];
 }
 
 export interface MinistryListResponse {
@@ -52,6 +83,21 @@ export interface LocaleItem {
 
 export interface LocaleListResponse {
   items: LocaleItem[];
+}
+
+export interface UpdateMinistryApplicationPayload {
+  ministryTypeId?: string;
+  targetAudienceIds?: string[];
+  hasPriorityBooking?: boolean;
+  translations?: Array<{
+    localeId: string;
+    name: string;
+    description?: string;
+  }>;
+  members?: Array<{
+    userId: string;
+    memberRole: "primary" | "secondary";
+  }>;
 }
 
 export interface CreateMinistryApplicationPayload {

--- a/src/utils/ministryStatus.test.ts
+++ b/src/utils/ministryStatus.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMinistryStatusBadgeColor,
+  isActiveMinistryStatus,
+  isRejectedMinistryStatus,
+  MINISTRY_STATUS,
+} from "./ministryStatus";
+
+describe("ministryStatus", () => {
+  it("defines lifecycle status constants", () => {
+    expect(MINISTRY_STATUS.PENDING_APPROVAL).toBe("pending_approval");
+    expect(MINISTRY_STATUS.REJECTED).toBe("rejected");
+    expect(MINISTRY_STATUS.ACTIVE).toBe("active");
+  });
+
+  it("detects active ministries", () => {
+    expect(isActiveMinistryStatus(MINISTRY_STATUS.ACTIVE, true)).toBe(true);
+    expect(isActiveMinistryStatus(MINISTRY_STATUS.ACTIVE, false)).toBe(false);
+    expect(isActiveMinistryStatus(MINISTRY_STATUS.PENDING_APPROVAL, true)).toBe(false);
+  });
+
+  it("detects rejected ministries", () => {
+    expect(isRejectedMinistryStatus(MINISTRY_STATUS.REJECTED)).toBe(true);
+    expect(isRejectedMinistryStatus(MINISTRY_STATUS.ACTIVE)).toBe(false);
+  });
+
+  it("maps status to badge colors", () => {
+    expect(getMinistryStatusBadgeColor(MINISTRY_STATUS.PENDING_APPROVAL)).toBe("warning");
+    expect(getMinistryStatusBadgeColor(MINISTRY_STATUS.REJECTED)).toBe("error");
+    expect(getMinistryStatusBadgeColor(MINISTRY_STATUS.ACTIVE)).toBe("success");
+    expect(getMinistryStatusBadgeColor("unknown")).toBe("light");
+  });
+});

--- a/src/utils/ministryStatus.ts
+++ b/src/utils/ministryStatus.ts
@@ -1,0 +1,30 @@
+export const MINISTRY_STATUS = {
+  PENDING_APPROVAL: "pending_approval",
+  REJECTED: "rejected",
+  ACTIVE: "active",
+} as const;
+
+export type MinistryLifecycleStatus = (typeof MINISTRY_STATUS)[keyof typeof MINISTRY_STATUS] | string;
+
+export type MinistryStatusBadgeColor = "warning" | "error" | "success" | "light";
+
+export const isActiveMinistryStatus = (status: string, isActive = true): boolean => {
+  return status === MINISTRY_STATUS.ACTIVE && isActive !== false;
+};
+
+export const isRejectedMinistryStatus = (status: string): boolean => {
+  return status === MINISTRY_STATUS.REJECTED;
+};
+
+export const getMinistryStatusBadgeColor = (status: string): MinistryStatusBadgeColor => {
+  switch (status) {
+    case MINISTRY_STATUS.PENDING_APPROVAL:
+      return "warning";
+    case MINISTRY_STATUS.REJECTED:
+      return "error";
+    case MINISTRY_STATUS.ACTIVE:
+      return "success";
+    default:
+      return "light";
+  }
+};


### PR DESCRIPTION
## Summary

- Replace the title-only My Ministry stub with a tabbed page: **My applications** (implemented) and **Pending my approval** (placeholder for #47).
- List pending, rejected, and active ministries from `GET /api/v1/ministry/ministries/mine?include_pending=true` with status badges and rejection reasons.
- Rejected applications open a resubmit modal (owner position locked) that calls `PUT /api/v1/ministry/applications/{id}` then `POST /api/v1/ministry/applications/{id}/submit`.
- Active ministries show a Start booking CTA; TopNav `ministryOnly` visibility is unchanged.
- Add i18n strings for `en`, `zh-TW`, and `zh-CN`.

Closes #46

Parent: #43

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] Open `/my-ministry` as a ministry member and confirm the applications list loads with correct status badges
- [ ] Rejected row shows rejection reason and opens resubmit modal with owner position read-only
- [ ] Resubmit updates and returns application to pending approval
- [ ] Active row links to Start booking (`/start-booking?step=select_ministry&ministry=1`)
- [ ] Confirm My Ministry nav still appears only for ministry members (including pending/rejected)


Made with [Cursor](https://cursor.com)