### PR TITLE
feat: refresh My Ministry nav after Create Ministry submit (#52)

### DIFF
--- a/docs/adr/0019-my-ministry-application-and-approval-queue.md
+++ b/docs/adr/0019-my-ministry-application-and-approval-queue.md
@@ -15,6 +15,7 @@ Create Ministry collects ministry type, optional target audiences, and at least 
 ## Consequences
 
 - Routes under `/my-ministry` and `/my-ministry/approvals/:id`; TopNav keeps existing My Ministry entry (`ministryOnly` visibility unchanged in spirit).
+- After Create Ministry submit succeeds, `MinistryMembershipContext` refreshes so TopNav shows **My Ministry** while the confirmation modal is still open; confirmation footer is **Close** (left) and **Go to My Ministry** (right, primary) → `/my-ministry` (default **My applications** tab). Scope: `CreateMinistryModal` only, not resubmit.
 - Depends on core-api member approval APIs and Graph mail (ADR 0012 in `newlife-core-api`).
 - Depends on post-login `next` allowlist for approval paths (#39).
 - Expands scope of issue #2 beyond list-only stub.

--- a/src/context/MinistryMembershipContext.tsx
+++ b/src/context/MinistryMembershipContext.tsx
@@ -1,11 +1,12 @@
 import { ministryService } from "@/api/services/ministryService";
 import { isMinistryMemberFromList } from "@/utils/visitAccess";
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
 
 interface MinistryMembershipContextType {
   isMinistryMember: boolean;
   canAccessMyMinistry: boolean;
   isLoading: boolean;
+  refreshMembership: () => Promise<void>;
 }
 
 const MinistryMembershipContext = createContext<MinistryMembershipContextType | undefined>(undefined);
@@ -19,42 +20,50 @@ export const MinistryMembershipProvider = ({ children }: MinistryMembershipProvi
   const [canAccessMyMinistry, setCanAccessMyMinistry] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
+  const loadMembership = useCallback(async (isCancelled?: () => boolean): Promise<void> => {
+    const cancelled = () => isCancelled?.() ?? false;
+
+    try {
+      const [mineResult, pendingResult] = await Promise.all([
+        ministryService.listMine(true),
+        ministryService.listPendingApprovalsForMe().catch(() => ({ items: [] })),
+      ]);
+      if (cancelled()) {
+        return;
+      }
+      const hasMinistries = isMinistryMemberFromList(mineResult.items || []);
+      const hasPendingApprovals = (pendingResult.items || []).length > 0;
+      setIsMinistryMember(hasMinistries);
+      setCanAccessMyMinistry(hasMinistries || hasPendingApprovals);
+    } catch {
+      if (!cancelled()) {
+        setIsMinistryMember(false);
+        setCanAccessMyMinistry(false);
+      }
+    }
+  }, []);
+
+  const refreshMembership = useCallback(async (): Promise<void> => {
+    await loadMembership();
+  }, [loadMembership]);
+
   useEffect(() => {
     let cancelled = false;
 
-    const loadMembership = async () => {
-      try {
-        const [mineResult, pendingResult] = await Promise.all([
-          ministryService.listMine(true),
-          ministryService.listPendingApprovalsForMe().catch(() => ({ items: [] })),
-        ]);
-        if (!cancelled) {
-          const hasMinistries = isMinistryMemberFromList(mineResult.items || []);
-          const hasPendingApprovals = (pendingResult.items || []).length > 0;
-          setIsMinistryMember(hasMinistries);
-          setCanAccessMyMinistry(hasMinistries || hasPendingApprovals);
-        }
-      } catch {
-        if (!cancelled) {
-          setIsMinistryMember(false);
-          setCanAccessMyMinistry(false);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+    void (async () => {
+      await loadMembership(() => cancelled);
+      if (!cancelled) {
+        setIsLoading(false);
       }
-    };
-
-    void loadMembership();
+    })();
 
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadMembership]);
 
   return (
-    <MinistryMembershipContext.Provider value={{ isMinistryMember, canAccessMyMinistry, isLoading }}>
+    <MinistryMembershipContext.Provider value={{ isMinistryMember, canAccessMyMinistry, isLoading, refreshMembership }}>
       {children}
     </MinistryMembershipContext.Provider>
   );

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -347,6 +347,7 @@
       "purposePlaceholder": "Enter the purpose",
       "submit": "Submit",
       "close": "Close",
+      "goToMyMinistry": "Go to My Ministry",
       "approvalTitle": "Approval required.",
       "approvalMessage": "Please wait for a confirmation email before you make a booking.",
       "submittedTitle": "Request submitted!",

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -347,6 +347,7 @@
       "purposePlaceholder": "输入用途",
       "submit": "提交",
       "close": "关闭",
+      "goToMyMinistry": "前往我的事工",
       "approvalTitle": "需要核准。",
       "approvalMessage": "请等待确认邮件后再进行预订。",
       "submittedTitle": "申请已提交！",

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -347,6 +347,7 @@
       "purposePlaceholder": "輸入用途",
       "submit": "送出",
       "close": "關閉",
+      "goToMyMinistry": "前往我的事工",
       "approvalTitle": "需要核准。",
       "approvalMessage": "請等待確認郵件後再進行預訂。",
       "submittedTitle": "申請已送出！",

--- a/src/pages/start-booking/CreateMinistryModal.tsx
+++ b/src/pages/start-booking/CreateMinistryModal.tsx
@@ -1,4 +1,5 @@
 import ministryService from "@/api/services/ministryService";
+import { useMinistryMembership } from "@/context/MinistryMembershipContext";
 import i18n from "@/i18n";
 import type { AssignablePosition, LocaleItem, MinistryCatalogItem, OrgUserSearchItem } from "@/types/ministry";
 import {
@@ -9,9 +10,11 @@ import {
   type CreateMinistryValidationKey,
 } from "@/utils/createMinistryForm";
 import { resolveMinistryApplicationErrorMessage } from "@/utils/ministryApplicationErrors";
+import { MY_MINISTRY_PATH } from "@/utils/visitAccess";
 import { Alert, Button, ComboBox, Input, ModalForm, type ModalFormHandle, Select } from "@efcnewlife/newlife-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 
 interface CreateMinistryModalProps {
   isOpen: boolean;
@@ -43,6 +46,8 @@ const formatUserLabel = (item: OrgUserSearchItem): string => {
 
 const CreateMinistryModal = ({ isOpen, userId, onClose, onSubmitted }: CreateMinistryModalProps) => {
   const { t } = useTranslation("booking");
+  const navigate = useNavigate();
+  const { refreshMembership } = useMinistryMembership();
   const modalRef = useRef<ModalFormHandle>(null);
   const [phase, setPhase] = useState<"form" | "confirmation">("form");
   const [positions, setPositions] = useState<AssignablePosition[]>([]);
@@ -160,6 +165,11 @@ const CreateMinistryModal = ({ isOpen, userId, onClose, onSubmitted }: CreateMin
     onClose();
   };
 
+  const handleGoToMyMinistry = () => {
+    onClose();
+    navigate(MY_MINISTRY_PATH);
+  };
+
   const validationMessage = (key: CreateMinistryValidationKey): string => t(`startBooking.errors.${key}`);
 
   const handleSubmit = async () => {
@@ -216,6 +226,7 @@ const CreateMinistryModal = ({ isOpen, userId, onClose, onSubmitted }: CreateMin
           })),
         ],
       });
+      await refreshMembership();
       setPhase("confirmation");
     } catch (err) {
       setError(resolveMinistryApplicationErrorMessage(err));
@@ -229,9 +240,14 @@ const CreateMinistryModal = ({ isOpen, userId, onClose, onSubmitted }: CreateMin
       className="max-w-2xl w-full mx-4 p-6"
       footer={
         phase === "confirmation" ? (
-          <Button onClick={handleClose} size="sm" variant="primary">
-            {t("startBooking.createMinistry.close")}
-          </Button>
+          <>
+            <Button onClick={handleClose} size="sm" variant="outline">
+              {t("startBooking.createMinistry.close")}
+            </Button>
+            <Button onClick={handleGoToMyMinistry} size="sm" variant="primary">
+              {t("startBooking.createMinistry.goToMyMinistry")}
+            </Button>
+          </>
         ) : (
           <>
             <Button onClick={handleClose} size="sm" variant="outline">


### PR DESCRIPTION
## Summary

After a member submits a Ministry Application from Create Ministry in Start booking, membership state refreshes immediately so TopNav shows **My Ministry** while the confirmation modal is still open. The confirmation footer adds **Go to My Ministry** (primary) alongside **Close** (outline).

Closes #52

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `MinistryMembershipContext` exposes `refreshMembership`, sharing the same `loadMembership` path as initial mount (`listMine(true)` + pending approvals).
- `CreateMinistryModal` calls `refreshMembership` after `createApplication` succeeds, before entering confirmation.
- **Close** still invokes `onSubmitted` for Start booking ministry picker refresh; **Go to My Ministry** navigates to `/my-ministry` (default My applications tab).
- ADR 0019 consequence updated. `ResubmitMinistryModal` unchanged.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] Manual E2E: Start booking → Create Ministry → submit → TopNav shows My Ministry before closing modal; **Go to My Ministry** → `/my-ministry`; **Close** → Start booking picker refresh

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)