### PR TITLE
feat(timetable): migrate Search Bar and secondary CTAs to Figma V3 (#57)

### DIFF
--- a/src/components/booking/RoomGridCard.tsx
+++ b/src/components/booking/RoomGridCard.tsx
@@ -47,7 +47,7 @@ const RoomGridCard = ({
 
         {variant === "by_room" ? (
           <button
-            className="h-9 min-w-[130px] shrink-0 rounded-[24px] bg-cta px-3 text-sm font-bold text-on-cta transition-colors hover:bg-cta-hover hover:text-on-cta-hover"
+            className="btn-booking-secondary h-9 min-w-[130px] shrink-0 rounded-[24px] px-3 text-sm font-bold"
             onClick={() => onSeeAvailability?.(room)}
             type="button"
           >

--- a/src/components/booking/RoomResultCard.tsx
+++ b/src/components/booking/RoomResultCard.tsx
@@ -70,7 +70,7 @@ const RoomResultCard = ({
 
           {!onSelectSlot ? (
             <button
-              className="h-9 min-w-[130px] shrink-0 self-start rounded-[24px] bg-cta px-3 text-sm font-bold text-on-cta transition-colors hover:bg-cta-hover hover:text-on-cta-hover lg:self-end"
+              className="btn-booking-secondary h-9 min-w-[130px] shrink-0 self-start rounded-[24px] px-3 text-sm font-bold lg:self-end"
               onClick={() => onSelectTime?.(room)}
               type="button"
             >

--- a/src/components/booking/RoomSelectionBar.tsx
+++ b/src/components/booking/RoomSelectionBar.tsx
@@ -40,7 +40,7 @@ const RoomSelectionBar = ({ selectedRooms, maxSelection = 3, onSeeAvailability }
         </div>
 
         <button
-          className="h-9 min-w-[130px] self-center rounded-[24px] bg-cta px-3 text-sm font-bold text-on-cta transition-colors hover:bg-cta-hover hover:text-on-cta-hover disabled:cursor-not-allowed disabled:opacity-50"
+          className="btn-booking-secondary h-9 min-w-[130px] self-center rounded-[24px] px-3 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
           disabled={!hasSelection}
           onClick={onSeeAvailability}
           type="button"

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -60,7 +60,10 @@ const ROOMS_PER_PAGE = 4;
 const SLOT_HEIGHT_PX = 40;
 const GRID_SCROLL_PADDING_PX = 16;
 const CAPACITY_BANDS: CapacityBand[] = ["1-10", "10-25", "25-50", "50+"];
-const SEARCH_LABEL_CLASS = "mb-[3px] text-xs font-medium leading-none text-inverse-on-surface";
+const SEARCH_LABEL_CLASS = "mb-[3px] text-xs font-medium leading-none text-booking-light-grey";
+const SEARCH_CONTROL_CLASS = "border-outline bg-surface";
+const SEARCH_SECONDARY_BUTTON_CLASS =
+  "btn-booking-secondary inline-flex items-center justify-center rounded-lg px-3 py-2 text-xs whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-50";
 const TIMETABLE_TRACK = "grid w-full grid-cols-[88px_repeat(4,minmax(0,1fr))] gap-x-[30px]";
 
 const isActiveMinistry = (item: MinistryItem): boolean => {
@@ -459,6 +462,7 @@ const RoomFilterPage = () => {
         <div className="flex min-w-0 flex-wrap items-end gap-2.5">
           {showMinistryField ? (
             <Select
+              className={SEARCH_CONTROL_CLASS}
               clearable
               id="timetable-ministry"
               label={t("timetable.ministry")}
@@ -476,7 +480,7 @@ const RoomFilterPage = () => {
             />
           ) : null}
           <Select
-            className="opacity-100"
+            className={cn("opacity-100", SEARCH_CONTROL_CLASS)}
             clearable={false}
             disabled
             id="timetable-repetition"
@@ -489,6 +493,7 @@ const RoomFilterPage = () => {
             wrapperClassName="w-[124px] shrink-0"
           />
           <DatePicker
+            className={SEARCH_CONTROL_CLASS}
             clearable={false}
             id="timetable-date"
             label={t("timetable.date")}
@@ -504,6 +509,7 @@ const RoomFilterPage = () => {
           />
           <TimePicker
             ampm
+            className={SEARCH_CONTROL_CLASS}
             id="timetable-start"
             label={t("timetable.start")}
             labelClassName={SEARCH_LABEL_CLASS}
@@ -515,6 +521,7 @@ const RoomFilterPage = () => {
           />
           <TimePicker
             ampm
+            className={SEARCH_CONTROL_CLASS}
             id="timetable-end"
             label={t("timetable.end")}
             labelClassName={SEARCH_LABEL_CLASS}
@@ -525,6 +532,7 @@ const RoomFilterPage = () => {
             wrapperClassName="w-[148px] shrink-0"
           />
           <Select
+            className={SEARCH_CONTROL_CLASS}
             clearable={false}
             id="timetable-space"
             label={t("timetable.roomsCount")}
@@ -541,15 +549,9 @@ const RoomFilterPage = () => {
           />
         </div>
         <span className="shrink-0" id="timetable-update-search">
-          <Button
-            btnType="button"
-            className="whitespace-nowrap !border-[0.5px] !border-booking-primary !bg-cta !text-on-cta hover:!bg-cta hover:!text-on-cta"
-            disabled={loading}
-            onClick={handleUpdateSearch}
-            size="xs"
-          >
+          <button className={SEARCH_SECONDARY_BUTTON_CLASS} disabled={loading} type="submit">
             {t("timetable.updateSearch")}
-          </Button>
+          </button>
         </span>
       </form>
 
@@ -612,14 +614,14 @@ const RoomFilterPage = () => {
           </div>
           <div className="flex shrink-0 items-center gap-4">
             {appliedSpace === "multiple" ? (
-              <Button
-                className="whitespace-nowrap !border-[0.5px] !border-booking-primary !bg-cta !text-on-cta hover:!bg-cta hover:!text-on-cta"
+              <button
+                className={SEARCH_SECONDARY_BUTTON_CLASS}
                 disabled={!canReviewBooking(selection)}
                 onClick={handleReviewBooking}
-                size="xs"
+                type="button"
               >
                 {t("timetable.reviewBookingCount", { count: selection.roomIds.length })}
-              </Button>
+              </button>
             ) : null}
             <div className="flex shrink-0 gap-3">
               <Button


### PR DESCRIPTION
## Summary

Align the Timetable Search Bar and yellow secondary actions with Figma V3 Search details and Secondary button tokens from ADR 0020. Search field labels use Light Grey, controls use white surfaces with grey borders, and **Update search** / **Review booking** use the shared `btn-booking-secondary` utility instead of `!important` color overrides. Orphan room card components are updated to the same secondary CTA pattern.

Closes #57

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- **Update search** and **Review booking** use native `<button>` elements with `btn-booking-secondary` to avoid style conflicts with `newlife-ui` `Button` default primary variant.
- Hover (`#d99013`) and active (`#d8d8d8`) states come from the `btn-booking-secondary` utility added in #55.

## Testing

- [x] `pnpm type-check`
- [x] `pnpm test`
- [ ] Manual spot-check: `/rooms` with a valid search query — Search Bar labels, white bordered controls, and yellow CTAs match Figma Search details

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)