### PR TITLE
feat(auth): mock login UI and remove dev login / skip auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,12 @@ VITE_APP_NAME=Facility Booking
 VITE_APP_TITLE=Facility Booking
 VITE_APP_VERSION=0.1.0
 
-# Development-only: show email dev sign-in on login page (no Microsoft, no API)
-VITE_SHOW_DEV_LOGIN=true
-# Optional default email for the dev sign-in field
-VITE_DEV_LOGIN_EMAIL=dev@local.test
-
-# Development-only: bypass auth guard and API tokens entirely
-# VITE_SKIP_AUTH=true
+# Non-production: show Mock login collapsible on Sign in (requires backend MOCK_LOGIN_ENABLED)
+VITE_SHOW_MOCK_LOGIN=true
+# Optional default email for the mock login field
+VITE_MOCK_LOGIN_EMAIL=qa@test.local
+# Staging only: shared secret sent as X-Mock-Login-Secret (leave empty in local dev)
+# VITE_MOCK_LOGIN_SECRET=
 
 # Microsoft Entra ID (optional)
 # VITE_AZURE_CLIENT_ID=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,21 +6,21 @@ This document helps AI agents quickly understand the **Facility Booking** member
 
 ## 1. What This Project Is
 
-| Item                | Value                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| **Purpose**         | Member-facing SPA for church facility (room) booking                               |
-| **Package**         | `facility-booking-frontend` `0.1.0` (`private`)                                    |
-| **Framework**       | React 19 + Vite 6 + TypeScript                                                     |
-| **Styling**         | Tailwind CSS v4 (CSS-first `@theme` in `src/index.css`); host owns tokens          |
-| **UI lib**          | `@efcnewlife/newlife-ui` (GitHub Packages)                                         |
-| **Router**          | React Router v7 (`react-router`) — routes centralized in `src/routes/index.tsx`    |
-| **HTTP**            | Axios via `httpClient`; app API prefix `/api/v1`                                   |
-| **Auth**            | Microsoft Entra ID (MSAL popup) → backend token exchange; optional dev email login |
-| **i18n**            | `i18next` + `react-i18next` (`en`, `zh-TW`, `zh-CN`)                               |
-| **Dates**           | `moment` (API dates are `YYYY-MM-DD` strings)                                      |
-| **Package manager** | pnpm only (`.npmrc`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`)                      |
-| **Tests**           | Vitest (Node). `pnpm test` for `src/**/*.test.ts`; also `pnpm type-check`          |
-| **CI**              | `.github/workflows/branch-name.yml` (PR head branch name)                          |
+| Item                | Value                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| **Purpose**         | Member-facing SPA for church facility (room) booking                                            |
+| **Package**         | `facility-booking-frontend` `0.1.0` (`private`)                                                 |
+| **Framework**       | React 19 + Vite 6 + TypeScript                                                                  |
+| **Styling**         | Tailwind CSS v4 (CSS-first `@theme` in `src/index.css`); host owns tokens                       |
+| **UI lib**          | `@efcnewlife/newlife-ui` (GitHub Packages)                                                      |
+| **Router**          | React Router v7 (`react-router`) — routes centralized in `src/routes/index.tsx`                 |
+| **HTTP**            | Axios via `httpClient`; app API prefix `/api/v1`                                                |
+| **Auth**            | Microsoft Entra ID (MSAL popup) → backend token exchange; optional mock login in non-production |
+| **i18n**            | `i18next` + `react-i18next` (`en`, `zh-TW`, `zh-CN`)                                            |
+| **Dates**           | `moment` (API dates are `YYYY-MM-DD` strings)                                                   |
+| **Package manager** | pnpm only (`.npmrc`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`)                                   |
+| **Tests**           | Vitest (Node). `pnpm test` for `src/**/*.test.ts`; also `pnpm type-check`                       |
+| **CI**              | `.github/workflows/branch-name.yml` (PR head branch name)                                       |
 
 `flatpickr`, `moment-timezone`, and `react-helmet-async` are listed in `package.json` but **unused in `src/`**. Do not assume they are part of the stack. `BookingDatePicker` is a custom moment calendar.
 
@@ -134,12 +134,12 @@ Routes are **centralized** in `src/routes/index.tsx` (unlike the portal's module
 
 ## 5. Auth
 
-| File                              | Role                                                                        |
-| --------------------------------- | --------------------------------------------------------------------------- |
-| `src/context/AuthContext.tsx`     | `AuthProvider`, `useAuth`; `loginWithMicrosoft`, `loginAsDevUser`, `logout` |
-| `src/auth/msalInstance.ts`        | `PublicClientApplication`, `ensureMsalReady`                                |
-| `src/api/services/authService.ts` | Token exchange, storage, profile, logout, dev login                         |
-| `src/pages/login/LoginPage.tsx`   | Sign-in UI                                                                  |
+| File                              | Role                                                                         |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| `src/context/AuthContext.tsx`     | `AuthProvider`, `useAuth`; `loginWithMicrosoft`, `loginAsMockUser`, `logout` |
+| `src/auth/msalInstance.ts`        | `PublicClientApplication`, `ensureMsalReady`                                 |
+| `src/api/services/authService.ts` | Token exchange, mock login, storage, profile, logout                         |
+| `src/pages/login/LoginPage.tsx`   | Sign-in UI                                                                   |
 
 ### Flow
 
@@ -156,14 +156,14 @@ Keys: `auth_token`, `refresh_token`, `refresh_token_expiry`, `user_data`, `remem
 
 `clearOppositeStorage` keeps the two stores from drifting. Token read order: `sessionStorage` then `localStorage`.
 
-### Dev flags (gated on `IS_DEV` in `src/config/env.ts`)
+### Mock login flags (non-production only; `src/config/env.ts`)
 
-| Flag                                                                           | Behavior                                                                                                        |
-| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `VITE_SHOW_DEV_LOGIN` → `IS_SHOW_DEV_LOGIN`                                    | Email-only sign-in form; `loginAsDevUser` — **no API**                                                          |
-| `VITE_DEV_LOGIN_EMAIL`                                                         | Default email (`dev@local.test`)                                                                                |
-| `VITE_SKIP_AUTH` → `IS_SKIP_AUTH`                                              | Placeholder token (`dev_token_skip_auth_mode`); context still needs stored `user_data` for a successful session |
-| `VITE_AZURE_CLIENT_ID` + `VITE_AZURE_TENANT_ID` → `IS_MICROSOFT_LOGIN_ENABLED` | Microsoft button                                                                                                |
+| Flag                                                                           | Behavior                                                                              |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `VITE_SHOW_MOCK_LOGIN` → `IS_SHOW_MOCK_LOGIN`                                  | Collapsible Mock login on Sign in; `loginAsMockUser` → `POST /api/v1/auth/mock-login` |
+| `VITE_MOCK_LOGIN_EMAIL`                                                        | Default email for mock login field (`qa@test.local`)                                  |
+| `VITE_MOCK_LOGIN_SECRET`                                                       | Sent as `X-Mock-Login-Secret` when set (staging)                                      |
+| `VITE_AZURE_CLIENT_ID` + `VITE_AZURE_TENANT_ID` → `IS_MICROSOFT_LOGIN_ENABLED` | Microsoft button                                                                      |
 
 Read env through `ENV_CONFIG` / `IS_*` in `src/config/env.ts`, never `import.meta.env` in business code.
 
@@ -187,12 +187,12 @@ A single `HttpClient` singleton (`src/api/services/httpClient.ts`) is the only n
 
 All paths live in `src/api/config/index.ts` under `API_ENDPOINTS` (`BOOKING_API_PREFIX = "/api/v1"`). Add new routes there — do not inline URL strings.
 
-| Group    | Paths in use                                                         |
-| -------- | -------------------------------------------------------------------- |
-| Auth     | `/auth/login/microsoft`, `/auth/logout`, `/auth/refresh`, `/auth/me` |
-| Ministry | `/ministry/ministries/mine`, `/ministry/applications`                |
-| Org      | `/org/positions/assignable`, `/org/locales`                          |
-| Facility | `/facility/rooms/availability`, `/facility/bookings`                 |
+| Group    | Paths in use                                                                             |
+| -------- | ---------------------------------------------------------------------------------------- |
+| Auth     | `/auth/mock-login`, `/auth/login/microsoft`, `/auth/logout`, `/auth/refresh`, `/auth/me` |
+| Ministry | `/ministry/ministries/mine`, `/ministry/applications`                                    |
+| Org      | `/org/positions/assignable`, `/org/locales`                                              |
+| Facility | `/facility/rooms/availability`, `/facility/bookings`                                     |
 
 Defined but unused by UI today: `MINISTRY.MINISTRY_TYPES`, `MINISTRY.TARGET_AUDIENCES`, `FACILITY.MY_BOOKINGS` (service method exists), `FACILITY.cancelBooking`.
 
@@ -200,7 +200,7 @@ Defined but unused by UI today: `MINISTRY.MINISTRY_TYPES`, `MINISTRY.TARGET_AUDI
 
 | Service           | Owns                                                                       |
 | ----------------- | -------------------------------------------------------------------------- |
-| `authService`     | Login, logout, me, storage, dev login                                      |
+| `authService`     | Login, mock login, logout, me, storage                                     |
 | `ministryService` | `listMine`, `listAssignablePositions`, `listLocales`, `createApplication`  |
 | `facilityService` | `getAvailability`, `createBooking`, `listMyBookings` (latter unused by UI) |
 
@@ -252,16 +252,16 @@ Pure helpers: `timeToMinutes`, `hasContiguousHours` (merges overlapping am/pm sl
 
 ## 8. Pages
 
-| Path                                    | Purpose                                                   |
-| --------------------------------------- | --------------------------------------------------------- |
-| `login/LoginPage.tsx`                   | Microsoft / optional dev email login, remember me, locale |
-| `home/HomePage.tsx`                     | Welcome + Start Booking                                   |
-| `start-booking/StartBookingPage.tsx`    | Start booking questions                                   |
-| `start-booking/CreateMinistryModal.tsx` | Create ministry application modal                         |
-| `rooms/RoomFilterPage.tsx`              | Results, filters, slot select, create booking             |
-| `my-bookings/MyBookingsPage.tsx`        | Upcoming/past — **mock data**                             |
-| `my-profile/MyProfilePage.tsx`          | Profile + payment history — **partial mock**              |
-| `contact/ContactPage.tsx`               | Stub                                                      |
+| Path                                    | Purpose                                              |
+| --------------------------------------- | ---------------------------------------------------- |
+| `login/LoginPage.tsx`                   | Microsoft / optional mock login, remember me, locale |
+| `home/HomePage.tsx`                     | Welcome + Start Booking                              |
+| `start-booking/StartBookingPage.tsx`    | Start booking questions                              |
+| `start-booking/CreateMinistryModal.tsx` | Create ministry application modal                    |
+| `rooms/RoomFilterPage.tsx`              | Results, filters, slot select, create booking        |
+| `my-bookings/MyBookingsPage.tsx`        | Upcoming/past — **mock data**                        |
+| `my-profile/MyProfilePage.tsx`          | Profile + payment history — **partial mock**         |
+| `contact/ContactPage.tsx`               | Stub                                                 |
 
 ---
 
@@ -339,14 +339,14 @@ Centralized in `src/config/env.ts`.
 | ----------------------------------------------------- | ---------------------------------------------------------- |
 | `VITE_API_BASE_URL`                                   | Default `http://127.0.0.1:8000`                            |
 | `VITE_API_TIMEOUT`                                    | Default `90000`                                            |
-| `VITE_SHOW_DEV_LOGIN`                                 | Dev email sign-in                                          |
-| `VITE_DEV_LOGIN_EMAIL`                                | Default `dev@local.test`                                   |
-| `VITE_SKIP_AUTH`                                      | Dev skip-auth helper                                       |
+| `VITE_SHOW_MOCK_LOGIN`                                | Mock login collapsible on Sign in                          |
+| `VITE_MOCK_LOGIN_EMAIL`                               | Default `qa@test.local`                                    |
+| `VITE_MOCK_LOGIN_SECRET`                              | Staging secret header for mock login                       |
 | `VITE_AZURE_CLIENT_ID` / `TENANT_ID` / `REDIRECT_URI` | MSAL (`REDIRECT_URI` defaults to `window.location.origin`) |
 | `VITE_APP_NAME` / `TITLE` / `VERSION`                 | Branding                                                   |
 | `NODE_AUTH_TOKEN`                                     | pnpm GitHub Packages (not a Vite var)                      |
 
-Derived flags: `IS_DEV`, `IS_SKIP_AUTH`, `IS_SHOW_DEV_LOGIN`, `IS_MICROSOFT_LOGIN_ENABLED`.
+Derived flags: `IS_DEV`, `IS_STAGING`, `IS_PROD`, `IS_SHOW_MOCK_LOGIN`, `IS_MICROSOFT_LOGIN_ENABLED`.
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,12 @@ The first authenticated screen. It welcomes the member and offers a Start Bookin
 _Avoid_: Landing, Find Space, dashboard, treating Home as Q1
 
 **Sign in**:
-The unauthenticated `/login` page. Top band: booking wordmark and locale selector; centered white card (~350px, 20px radius) with compact church logo, Microsoft sign-in, and Remember me. Terms of Service and Privacy Policy links sit below the card as caption links. Dev email sign-in is collapsible when enabled locally. Microsoft outline button matches portal parity (ADR 0020). Not Landing — see **Home** for the first authenticated screen.
-_Avoid_: Landing as the product name, email/password as production auth, SupportFooter on Sign in, wide church wordmark or app title heading in the card, Forgot password or Sign up on Sign in
+The unauthenticated `/login` page. Top band: booking wordmark and locale selector; centered white card (~350px, 20px radius) with compact church logo, Microsoft sign-in, and Remember me. Terms of Service and Privacy Policy links sit below the card as caption links. Mock login is collapsible when enabled in non-production. Microsoft outline button matches portal parity (ADR 0020). Not Landing — see **Home** for the first authenticated screen.
+_Avoid_: Landing as the product name, email/password as production auth, SupportFooter on Sign in, wide church wordmark or app title heading in the card, Forgot password or Sign up on Sign in, dev login as the product name
+
+**Mock login**:
+Passwordless sign-in for Facility Booking in development and staging only. The member enters the email of a testing account; the app obtains a real backend session without Microsoft. Testing accounts use the `@test.local` email domain and are provisioned only by operator scripts, not self-registration or the admin portal. Each testing account keeps its own ministry and booking relationships in the database — mock login does not grant superuser bypass. Not production auth.
+_Avoid_: dev login, fake local session, frontend-only token, treating mock login as Microsoft, creating testing accounts from the Sign in page
 
 **Support**:
 The member-facing help page for special requests.

--- a/docs/adr/0021-mock-login.md
+++ b/docs/adr/0021-mock-login.md
@@ -1,0 +1,20 @@
+# Mock login for dev and staging QA without Microsoft
+
+QA and developers need to sign in to Facility Booking without Microsoft Entra ID and without a password, while exercising **real** backend sessions (bookings, ministries, approvals). The old dev email sign-in created a frontend-only fake token that API calls rejected. **Mock login** replaces that path: `POST /api/v1/auth/mock-login` with `{ email }` returns the same member JWT shape as Microsoft login. Only **development and staging** may enable it; production must not. Testing accounts are identified by email suffix `@test.local` (configurable via `TESTING_ACCOUNT_EMAIL_SUFFIX`); no `is_testing_account` DB column. Accounts are provisioned by operator CLI only ([newlife-core-api#118](https://github.com/efcnewlife/newlife-core-api/issues/118)), not Admin UI or self-registration. Each testing account keeps its own ministry and booking relationships — mock login does not bypass business rules. Staging also requires a shared secret header (`X-Mock-Login-Secret`). Failed attempts return a generic `401` whether the suffix or account is wrong. `VITE_SKIP_AUTH` is removed; use mock login or Microsoft instead.
+
+## Considered Options
+
+- **Keep frontend-only dev login (`dev_token_local_login`)** — rejected: API calls 401; QA cannot test real flows.
+- **`is_testing_account` boolean on `auth.user`** — rejected: suffix `@test.local` is enough, avoids migration and Admin checkbox; trade-off is testing accounts cannot use real-looking email domains.
+- **`POST /api/v1/auth/login/testing`** — rejected: `/mock-login` matches product language and grilling consensus.
+- **Superuser bypass for testing accounts** — rejected: staging QA must match production authorization rules per account.
+- **Keep `VITE_SKIP_AUTH` alongside mock login** — rejected: two bypass paths confuse QA; mock login covers non-Microsoft testing with real tokens.
+- **Mock login in production with IP allowlist** — rejected: dev/staging only.
+
+## Consequences
+
+- Frontend: replace `VITE_SHOW_DEV_LOGIN` / `loginAsDevUser` with `VITE_SHOW_MOCK_LOGIN` and `loginAsMockUser` calling the API; remove fake token helpers.
+- Backend (separate implementation): `MOCK_LOGIN_ENABLED`, `MOCK_LOGIN_SECRET`, suffix validation, Origin binding via `MEMBER_WEB_APPS`, reuse `complete_member_login` — see [newlife-core-api ADR 0014](https://github.com/efcnewlife/newlife-core-api/blob/main/docs/adr/0014-mock-login-member-auth.md).
+- `CONTEXT.md`: **Mock login** glossary; **Sign in** references mock login collapsible in non-production.
+- QA docs: retire or rewrite TC-AUTH-011 (dev login) and TC-AUTH-012 (`VITE_SKIP_AUTH`); add mock-login cases for dev/staging.
+- Persona seeding (owner vs steward vs non-ministry `@test.local` users) is out of scope for the mock-login mechanism — follow-up ticket.

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -4,6 +4,7 @@ const BOOKING_API_PREFIX = "/api/v1";
 
 export const API_ENDPOINTS = {
   AUTH: {
+    MOCK_LOGIN: `${BOOKING_API_PREFIX}/auth/mock-login`,
     MICROSOFT: `${BOOKING_API_PREFIX}/auth/login/microsoft`,
     LOGOUT: `${BOOKING_API_PREFIX}/auth/logout`,
     REFRESH: `${BOOKING_API_PREFIX}/auth/refresh`,

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -1,8 +1,8 @@
 import { API_ENDPOINTS } from "@/api/config";
-import { ENV_CONFIG, IS_SKIP_AUTH } from "@/config/env";
+import { ENV_CONFIG } from "@/config/env";
 import i18n from "@/i18n";
 import type { ApiError, ApiResponse, TokenResponse } from "@/types/api";
-import type { AuthError, DevLoginCredentials, LoginResponse, User } from "@/types/auth";
+import type { AuthError, LoginResponse, MockLoginCredentials, User } from "@/types/auth";
 import { httpClient } from "./httpClient";
 
 interface MemberInfoResponse {
@@ -26,27 +26,6 @@ const REFRESH_TOKEN_KEY = "refresh_token";
 const USER_KEY = "user_data";
 const REMEMBER_ME_KEY = "remember_me";
 const REMEMBER_ME_EXPIRY = 30 * 24 * 60 * 60 * 1000;
-const DEV_TOKEN_PREFIX = "dev_token_local_login";
-
-const createDevUser = (email: string): User => {
-  const nowIso = new Date().toISOString();
-  return {
-    id: "00000000-0000-4000-8000-000000000001",
-    username: email,
-    email,
-    firstName: "Dev",
-    lastName: "User",
-    preferredName: "Dev User",
-    status: "active",
-    roles: ["member"],
-    createdAt: nowIso,
-    updatedAt: nowIso,
-  };
-};
-
-const isLocalDevToken = (token: string | null): boolean => {
-  return Boolean(token?.startsWith(DEV_TOKEN_PREFIX));
-};
 
 const mapMemberToUser = (member: MemberInfoResponse): User => {
   const nowIso = new Date().toISOString();
@@ -64,6 +43,25 @@ const mapMemberToUser = (member: MemberInfoResponse): User => {
   };
 };
 
+const storeMemberLogin = (response: MemberLoginResponse, rememberMe: boolean): ApiResponse<LoginResponse> => {
+  const accessToken = response.token.accessToken;
+  const user = mapMemberToUser(response.member);
+  const refreshToken = response.token.refreshToken;
+  const expiresAt = new Date(Date.now() + response.token.expiresIn * 1000).toISOString();
+
+  return {
+    success: true,
+    data: {
+      user,
+      token: accessToken,
+      refreshToken,
+      expiresAt,
+      rememberMe,
+    },
+    code: 200,
+  };
+};
+
 class AuthService {
   private inFlightCurrentUserPromise: Promise<ApiResponse<User>> | null = null;
 
@@ -74,32 +72,8 @@ class AuthService {
       });
 
       if (response.success && response.data) {
-        const accessToken = response.data.token.accessToken;
-        const user = mapMemberToUser(response.data.member);
-        const refreshToken = response.data.token.refreshToken;
-        const expiresAt = new Date(Date.now() + response.data.token.expiresIn * 1000).toISOString();
-
-        this.setRememberMe(rememberMe);
-        this.setToken(accessToken);
-        this.clearOppositeStorage(rememberMe);
-
-        if (refreshToken && rememberMe) {
-          this.setRefreshToken(refreshToken);
-        }
-
-        this.setUser(user);
-
-        return {
-          success: true,
-          data: {
-            user,
-            token: accessToken,
-            refreshToken,
-            expiresAt,
-            rememberMe,
-          },
-          code: response.code,
-        };
+        this.persistLogin(response.data, rememberMe);
+        return storeMemberLogin(response.data, rememberMe);
       }
 
       return {
@@ -114,39 +88,48 @@ class AuthService {
     }
   }
 
-  /**
-   * Development-only local sign-in without Microsoft or backend API.
-   */
-  loginAsDevUser(credentials: DevLoginCredentials): ApiResponse<LoginResponse> {
-    const email = credentials.email.trim() || ENV_CONFIG.DEV_LOGIN_EMAIL;
+  async loginAsMockUser(credentials: MockLoginCredentials): Promise<ApiResponse<LoginResponse>> {
+    const email = credentials.email.trim() || ENV_CONFIG.MOCK_LOGIN_EMAIL;
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailPattern.test(email)) {
       return {
         success: false,
         data: undefined as unknown as LoginResponse,
         code: 400,
-        message: i18n.t("auth:devLoginInvalidEmail"),
+        message: i18n.t("auth:mockLoginInvalidEmail"),
       };
     }
 
-    const user = createDevUser(email);
-    const token = `${DEV_TOKEN_PREFIX}:${email}`;
     const rememberMe = credentials.rememberMe ?? false;
+    const mockLoginSecret = ENV_CONFIG.MOCK_LOGIN_SECRET.trim();
+    const headers: Record<string, string> = {};
+    if (mockLoginSecret) {
+      headers["X-Mock-Login-Secret"] = mockLoginSecret;
+    }
 
-    this.setRememberMe(rememberMe);
-    this.setToken(token);
-    this.clearOppositeStorage(rememberMe);
-    this.setUser(user);
+    try {
+      const response = await httpClient.request<MemberLoginResponse>({
+        method: "POST",
+        url: API_ENDPOINTS.AUTH.MOCK_LOGIN,
+        data: { email },
+        headers,
+      });
 
-    return {
-      success: true,
-      data: {
-        user,
-        token,
-        rememberMe,
-      },
-      code: 200,
-    };
+      if (response.success && response.data) {
+        this.persistLogin(response.data, rememberMe);
+        return storeMemberLogin(response.data, rememberMe);
+      }
+
+      return {
+        success: false,
+        data: undefined as unknown as LoginResponse,
+        code: response.code,
+        error: response.error,
+        message: response.message,
+      };
+    } catch (error) {
+      throw this.handleAuthError(error);
+    }
   }
 
   async logout(): Promise<ApiResponse<void>> {
@@ -175,12 +158,6 @@ class AuthService {
 
     this.inFlightCurrentUserPromise = (async () => {
       try {
-        const storedUser = this.getUser();
-        const storedToken = this.getToken();
-        if (isLocalDevToken(storedToken) && storedUser) {
-          return { success: true, data: storedUser, code: 200 };
-        }
-
         const response = await httpClient.get<MemberInfoResponse>(API_ENDPOINTS.AUTH.PROFILE);
 
         if (response.success && response.data) {
@@ -207,24 +184,12 @@ class AuthService {
   }
 
   isAuthenticated(): boolean {
-    if (IS_SKIP_AUTH) {
-      return true;
-    }
-
     const token = this.getToken();
     const user = this.getUser();
-    if (isLocalDevToken(token) && user) {
-      return true;
-    }
-
     return Boolean(token && user);
   }
 
   getToken(): string | null {
-    if (IS_SKIP_AUTH) {
-      return "dev_token_skip_auth_mode";
-    }
-
     const sessionToken = sessionStorage.getItem(TOKEN_KEY);
     if (sessionToken) {
       return sessionToken;
@@ -266,6 +231,22 @@ class AuthService {
     sessionStorage.removeItem(TOKEN_KEY);
     sessionStorage.removeItem(REFRESH_TOKEN_KEY);
     sessionStorage.removeItem(USER_KEY);
+  }
+
+  private persistLogin(response: MemberLoginResponse, rememberMe: boolean): void {
+    const accessToken = response.token.accessToken;
+    const user = mapMemberToUser(response.member);
+    const refreshToken = response.token.refreshToken;
+
+    this.setRememberMe(rememberMe);
+    this.setToken(accessToken);
+    this.clearOppositeStorage(rememberMe);
+
+    if (refreshToken && rememberMe) {
+      this.setRefreshToken(refreshToken);
+    }
+
+    this.setUser(user);
   }
 
   private setToken(token: string): void {

--- a/src/api/services/httpClient.ts
+++ b/src/api/services/httpClient.ts
@@ -217,7 +217,7 @@ class HttpClient {
 
   private isLoginRequest(config: AxiosRequestConfig): boolean {
     const url = typeof config.url === "string" ? config.url : "";
-    return url === API_ENDPOINTS.AUTH.MICROSOFT;
+    return url === API_ENDPOINTS.AUTH.MICROSOFT || url === API_ENDPOINTS.AUTH.MOCK_LOGIN;
   }
 
   private async getOrCreateRefreshPromise(): Promise<string> {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,9 +11,9 @@ export const ENV_CONFIG = {
   API_BASE_URL: import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:8000",
   API_TIMEOUT: parseInt(import.meta.env.VITE_API_TIMEOUT || "90000", 10),
 
-  SKIP_AUTH: import.meta.env.VITE_SKIP_AUTH === "true",
-  SHOW_DEV_LOGIN: import.meta.env.VITE_SHOW_DEV_LOGIN === "true",
-  DEV_LOGIN_EMAIL: (import.meta.env.VITE_DEV_LOGIN_EMAIL as string | undefined) || "dev@local.test",
+  SHOW_MOCK_LOGIN: import.meta.env.VITE_SHOW_MOCK_LOGIN === "true",
+  MOCK_LOGIN_EMAIL: (import.meta.env.VITE_MOCK_LOGIN_EMAIL as string | undefined) || "qa@test.local",
+  MOCK_LOGIN_SECRET: (import.meta.env.VITE_MOCK_LOGIN_SECRET as string | undefined) || "",
 
   AZURE_CLIENT_ID: (import.meta.env.VITE_AZURE_CLIENT_ID as string | undefined) || "",
   AZURE_TENANT_ID: (import.meta.env.VITE_AZURE_TENANT_ID as string | undefined) || "",
@@ -21,7 +21,8 @@ export const ENV_CONFIG = {
 } as const;
 
 export const IS_DEV = ENV_CONFIG.APP_ENV === "development";
-export const IS_SKIP_AUTH = IS_DEV && ENV_CONFIG.SKIP_AUTH;
-export const IS_SHOW_DEV_LOGIN = IS_DEV && ENV_CONFIG.SHOW_DEV_LOGIN;
+export const IS_STAGING = ENV_CONFIG.APP_ENV === "staging";
+export const IS_PROD = ENV_CONFIG.APP_ENV === "production";
+export const IS_SHOW_MOCK_LOGIN = !IS_PROD && ENV_CONFIG.SHOW_MOCK_LOGIN;
 export const IS_MICROSOFT_LOGIN_ENABLED =
   Boolean(ENV_CONFIG.AZURE_CLIENT_ID?.trim()) && Boolean(ENV_CONFIG.AZURE_TENANT_ID?.trim());

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,8 +1,7 @@
 import { ensureMsalReady, MSAL_LOGIN_SCOPES } from "@/auth/msalInstance";
 import { authService } from "@/api/services/authService";
-import { IS_SKIP_AUTH } from "@/config/env";
 import i18n from "@/i18n";
-import type { AuthState, DevLoginCredentials, User } from "@/types/auth";
+import type { AuthState, MockLoginCredentials, User } from "@/types/auth";
 import { createContext, type ReactNode, useContext, useEffect, useReducer } from "react";
 
 type AuthAction =
@@ -14,7 +13,7 @@ type AuthAction =
 
 interface AuthContextType extends AuthState {
   loginWithMicrosoft: (rememberMe: boolean) => Promise<void>;
-  loginAsDevUser: (credentials: DevLoginCredentials) => Promise<void>;
+  loginAsMockUser: (credentials: MockLoginCredentials) => Promise<void>;
   logout: () => Promise<void>;
   clearError: () => void;
 }
@@ -76,20 +75,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   useEffect(() => {
     const initializeAuth = async () => {
-      if (IS_SKIP_AUTH) {
-        const devUser = authService.getUser();
-        const devToken = authService.getToken();
-        if (devUser && devToken) {
-          dispatch({
-            type: "AUTH_SUCCESS",
-            payload: { user: devUser, token: devToken },
-          });
-        } else {
-          dispatch({ type: "AUTH_FAILURE", payload: "" });
-        }
-        return;
-      }
-
       if (!authService.isAuthenticated()) {
         const hasAccessToken = Boolean(authService.getToken());
         const hasRefreshToken = Boolean(authService.getRefreshToken());
@@ -161,10 +146,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     }
   };
 
-  const loginAsDevUser = async (credentials: DevLoginCredentials) => {
+  const loginAsMockUser = async (credentials: MockLoginCredentials) => {
     try {
       dispatch({ type: "AUTH_START" });
-      const response = authService.loginAsDevUser(credentials);
+      const response = await authService.loginAsMockUser(credentials);
 
       if (response.success && response.data) {
         const token = authService.getToken();
@@ -175,13 +160,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       } else {
         dispatch({
           type: "AUTH_FAILURE",
-          payload: response.message || i18n.t("auth:devLoginFailed"),
+          payload: response.message || i18n.t("auth:mockLoginFailed"),
         });
       }
     } catch (error) {
       dispatch({
         type: "AUTH_FAILURE",
-        payload: error instanceof Error ? error.message : i18n.t("auth:devLoginFailed"),
+        payload: error instanceof Error ? error.message : i18n.t("auth:mockLoginFailed"),
       });
     }
   };
@@ -203,7 +188,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const value: AuthContextType = {
     ...state,
     loginWithMicrosoft,
-    loginAsDevUser,
+    loginAsMockUser,
     logout,
     clearError,
   };

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -7,11 +7,11 @@
   "noIdTokenFromMicrosoft": "No ID token from Microsoft",
   "microsoftSignInFailed": "Microsoft sign-in failed",
   "signInPromptMicrosoft": "Sign in with your Microsoft account.",
-  "signInPromptDev": "Development only: enter an email to sign in locally without Microsoft or API.",
-  "devEmailSignInSection": "Dev sign-in (development only)",
-  "signInWithEmailDev": "Sign in (Dev)",
+  "signInPromptMock": "Enter the email of a testing account (@test.local).",
+  "mockLoginSection": "Mock login",
+  "signInWithMockLogin": "Sign in (Mock)",
   "signingIn": "Signing in...",
   "email": "Email",
-  "devLoginInvalidEmail": "Enter a valid email address",
-  "devLoginFailed": "Dev sign-in failed"
+  "mockLoginInvalidEmail": "Enter a valid email address",
+  "mockLoginFailed": "Mock sign-in failed"
 }

--- a/src/i18n/locales/zh-CN/auth.json
+++ b/src/i18n/locales/zh-CN/auth.json
@@ -7,11 +7,11 @@
   "noIdTokenFromMicrosoft": "未获取 Microsoft ID token",
   "microsoftSignInFailed": "Microsoft 登录失败",
   "signInPromptMicrosoft": "使用您的 Microsoft 账号登录。",
-  "signInPromptDev": "仅供开发环境：输入 Email 即可本地登录，无需 Microsoft 或 API。",
-  "devEmailSignInSection": "开发用登录（仅 development）",
-  "signInWithEmailDev": "开发登录",
+  "signInPromptMock": "输入测试账号的 Email（@test.local）。",
+  "mockLoginSection": "Mock 登录",
+  "signInWithMockLogin": "Mock 登录",
   "signingIn": "登录中...",
   "email": "Email",
-  "devLoginInvalidEmail": "请输入有效的 Email",
-  "devLoginFailed": "开发登录失败"
+  "mockLoginInvalidEmail": "请输入有效的 Email",
+  "mockLoginFailed": "Mock 登录失败"
 }

--- a/src/i18n/locales/zh-TW/auth.json
+++ b/src/i18n/locales/zh-TW/auth.json
@@ -7,11 +7,11 @@
   "noIdTokenFromMicrosoft": "未取得 Microsoft ID token",
   "microsoftSignInFailed": "Microsoft 登入失敗",
   "signInPromptMicrosoft": "使用您的 Microsoft 帳號登入。",
-  "signInPromptDev": "僅供開發環境：輸入 Email 即可本地登入，無需 Microsoft 或 API。",
-  "devEmailSignInSection": "開發用登入（僅 development）",
-  "signInWithEmailDev": "開發登入",
+  "signInPromptMock": "輸入測試帳號的 Email（@test.local）。",
+  "mockLoginSection": "Mock 登入",
+  "signInWithMockLogin": "Mock 登入",
   "signingIn": "登入中...",
   "email": "Email",
-  "devLoginInvalidEmail": "請輸入有效的 Email",
-  "devLoginFailed": "開發登入失敗"
+  "mockLoginInvalidEmail": "請輸入有效的 Email",
+  "mockLoginFailed": "Mock 登入失敗"
 }

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import AuthLocaleSelect from "@/components/auth/AuthLocaleSelect";
 import MicrosoftColorIcon from "@/components/auth/MicrosoftColorIcon";
 import LegalDocumentLinks from "@/components/legal/LegalDocumentLinks";
-import { ENV_CONFIG, IS_MICROSOFT_LOGIN_ENABLED, IS_SHOW_DEV_LOGIN } from "@/config/env";
+import { ENV_CONFIG, IS_MICROSOFT_LOGIN_ENABLED, IS_SHOW_MOCK_LOGIN } from "@/config/env";
 import { useAuth } from "@/context/AuthContext";
 import { resolvePostLoginNext } from "@/utils/resolvePostLoginNext";
 import { Button, Checkbox, cn, Input } from "@efcnewlife/newlife-ui";
@@ -12,16 +12,16 @@ import { useNavigate, useSearchParams } from "react-router";
 const LoginPage = () => {
   const { t } = useTranslation();
   const [rememberMe, setRememberMe] = useState(false);
-  const [devEmail, setDevEmail] = useState(ENV_CONFIG.DEV_LOGIN_EMAIL);
+  const [mockEmail, setMockEmail] = useState(ENV_CONFIG.MOCK_LOGIN_EMAIL);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { loginWithMicrosoft, loginAsDevUser, isLoading, error, isAuthenticated, clearError } = useAuth();
+  const { loginWithMicrosoft, loginAsMockUser, isLoading, error, isAuthenticated, clearError } = useAuth();
   const postLoginPath = resolvePostLoginNext(searchParams.get("next"));
 
-  const isDevEmailValid = useMemo(() => {
+  const isMockEmailValid = useMemo(() => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailPattern.test(devEmail.trim());
-  }, [devEmail]);
+    return emailPattern.test(mockEmail.trim());
+  }, [mockEmail]);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -39,11 +39,11 @@ const LoginPage = () => {
     }
   };
 
-  const handleDevSignIn = async (event: React.FormEvent) => {
+  const handleMockSignIn = async (event: React.FormEvent) => {
     event.preventDefault();
     clearError();
     try {
-      await loginAsDevUser({ email: devEmail, rememberMe });
+      await loginAsMockUser({ email: mockEmail, rememberMe });
       navigate(postLoginPath, { replace: true });
     } catch (signInError) {
       console.error(signInError);
@@ -81,7 +81,7 @@ const LoginPage = () => {
 
           {IS_MICROSOFT_LOGIN_ENABLED && (
             <>
-              {!IS_SHOW_DEV_LOGIN && (
+              {!IS_SHOW_MOCK_LOGIN && (
                 <p className="mb-5 text-center text-[17.5px] font-medium text-on-surface-variant">
                   {t("auth:signInPromptMicrosoft")}
                 </p>
@@ -105,32 +105,32 @@ const LoginPage = () => {
             </>
           )}
 
-          {!IS_MICROSOFT_LOGIN_ENABLED && !IS_SHOW_DEV_LOGIN && (
+          {!IS_MICROSOFT_LOGIN_ENABLED && !IS_SHOW_MOCK_LOGIN && (
             <p className="text-center text-[17.5px] font-medium text-on-surface-variant">
               {t("auth:microsoftNotConfiguredEnv")}
             </p>
           )}
 
-          {IS_SHOW_DEV_LOGIN && (
+          {IS_SHOW_MOCK_LOGIN && (
             <details className={cn("w-full", IS_MICROSOFT_LOGIN_ENABLED && "mt-[30px]")}>
               <summary className="cursor-pointer text-center text-[15px] font-medium text-on-surface-variant">
-                {t("auth:devEmailSignInSection")}
+                {t("auth:mockLoginSection")}
               </summary>
 
               <div className="mt-5">
                 <p className="mb-5 text-center text-[17.5px] font-medium text-on-surface-variant">
-                  {t("auth:signInPromptDev")}
+                  {t("auth:signInPromptMock")}
                 </p>
 
-                <form className="space-y-5" onSubmit={handleDevSignIn}>
+                <form className="space-y-5" onSubmit={handleMockSignIn}>
                   <Input
-                    id="dev-email"
+                    id="mock-login-email"
                     label={t("auth:email")}
-                    onChange={(event) => setDevEmail(event.target.value)}
-                    placeholder="dev@local.test"
+                    onChange={(event) => setMockEmail(event.target.value)}
+                    placeholder="qa@test.local"
                     required
                     type="email"
-                    value={devEmail}
+                    value={mockEmail}
                   />
 
                   {!IS_MICROSOFT_LOGIN_ENABLED && (
@@ -142,11 +142,11 @@ const LoginPage = () => {
                   <Button
                     btnType="submit"
                     className="w-full"
-                    disabled={isLoading || !isDevEmailValid}
+                    disabled={isLoading || !isMockEmailValid}
                     size="md"
                     variant="outline"
                   >
-                    {isLoading ? t("auth:signingIn") : t("auth:signInWithEmailDev")}
+                    {isLoading ? t("auth:signingIn") : t("auth:signInWithMockLogin")}
                   </Button>
                 </form>
               </div>

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -28,7 +28,7 @@ export interface LoginResponse {
   rememberMe?: boolean;
 }
 
-export interface DevLoginCredentials {
+export interface MockLoginCredentials {
   email: string;
   rememberMe?: boolean;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,9 +7,9 @@ interface ImportMetaEnv {
   readonly VITE_APP_NAME: string;
   readonly VITE_APP_TITLE: string;
   readonly VITE_APP_VERSION: string;
-  readonly VITE_SKIP_AUTH?: string;
-  readonly VITE_SHOW_DEV_LOGIN?: string;
-  readonly VITE_DEV_LOGIN_EMAIL?: string;
+  readonly VITE_SHOW_MOCK_LOGIN?: string;
+  readonly VITE_MOCK_LOGIN_EMAIL?: string;
+  readonly VITE_MOCK_LOGIN_SECRET?: string;
   readonly VITE_AZURE_CLIENT_ID?: string;
   readonly VITE_AZURE_TENANT_ID?: string;
   readonly VITE_AZURE_REDIRECT_URI?: string;


### PR DESCRIPTION
## Summary

Replace the frontend-only dev email sign-in and `VITE_SKIP_AUTH` bypass with real backend mock login for non-production QA. Sign in exposes a collapsible Mock login section that calls `POST /api/v1/auth/mock-login`, stores member JWTs like Microsoft login, and supports optional `X-Mock-Login-Secret` for staging.

Closes #67

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [x] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `VITE_SHOW_MOCK_LOGIN` / `VITE_MOCK_LOGIN_EMAIL` / `VITE_MOCK_LOGIN_SECRET` replace `VITE_SHOW_DEV_LOGIN`, `VITE_DEV_LOGIN_EMAIL`, and `VITE_SKIP_AUTH`.
- Mock login UI is hidden in production builds (`IS_SHOW_MOCK_LOGIN = !IS_PROD && …`).
- ADR 0021 and CONTEXT mock-login glossary added; Booking/Timetable glossary left unchanged.
- Requires backend mock-login API ([newlife-core-api#119](https://github.com/efcnewlife/newlife-core-api/issues/119)) with `MOCK_LOGIN_ENABLED=true` and provisioned `@test.local` accounts.

## Testing

- [x] `pnpm type-check`
- [x] `pnpm test`
- [ ] Manual: Mock login on Sign in → Home → authenticated API succeeds (with backend mock login enabled)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)