### PR TITLE
feat: drop Space needed from Start booking flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,14 +235,14 @@ Authenticated welcome plus a Start Booking action. No question stepper.
 Driven by `?step=` (and `ministry=1|0` after Q1). Step transitions, When validation, and Rooms query building live in `src/utils/startBookingFlow.ts`:
 
 ```ts
-type StartBookingStep = "ministry_choice" | "select_ministry" | "frequency" | "when" | "space_needed";
+type StartBookingStep = "ministry_choice" | "select_ministry" | "frequency" | "when";
 ```
 
-Typical progression: ministry yes/no → (ministry name if Yes) → One-time vs Repeated → date and time → Space needed → navigate to `/rooms?...`. Create ministry is a modal on ministry name. The current step is mirrored into the URL with `{ replace: true }`.
+Typical progression: ministry yes/no → (ministry name if Yes) → One-time vs Repeated → date and time → navigate to `/rooms?...`. Create ministry is a modal on ministry name. The current step is mirrored into the URL with `{ replace: true }`. When Search sends `date` with optional `start`/`end` and optional `ministryId` only.
 
 ### 3. Results — `src/pages/rooms/RoomFilterPage.tsx`
 
-Reads Start booking output via `parseRoomsSearchQuery`. Missing or invalid `date` redirects to Home. Query: `date`, `start`, `end`, `space=single|multiple`, optional `ministryId`, optional `room` (`gym` / `sanctuary-hall`). Extra keys may be ignored until the timetable slice. Loads via `facilityService.getAvailability(date, ministryId)`, then client-filters. Can create a booking (max 3 rooms). Booking datetimes are `moment(...).toISOString()`.
+Reads Start booking output via `parseRoomsSearchQuery`. Missing or invalid `date` redirects to Home. Query: `date`, optional `start`/`end`, optional `ministryId`. Legacy `space` / `room` URL params are ignored on entry. Loads via `facilityService.getAvailability(date, ministryId)`, then client-filters. Can create a booking (max 3 rooms). Booking datetimes are `moment(...).toISOString()`.
 
 ### Availability filter — `src/utils/roomAvailabilityFilter.ts`
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,28 +81,44 @@ The booking create form finds secondary stewards among active auth users by emai
 _Avoid_: invite-by-email without an existing auth user, searching Member Person records
 
 **Start booking**:
-The question flow after Home. Ministry choice: Yes goes to ministry name, No skips to One-time vs Repeated, then When, then Space needed. Search leaves this flow for the Timetable.
-_Avoid_: Landing, Find Space, wizard (as the product name), Rooms as the member-facing name of the post-Search screen
+The question flow after Home. Ministry choice: Yes goes to ministry name, No skips to One-time vs Repeated, then When. Search leaves this flow for the Timetable. There is no Space needed step.
+_Avoid_: Landing, Find Space, wizard (as the product name), Rooms as the member-facing name of the post-Search screen, Space needed, Room shortcut on this flow
 
 **One-time**:
-A booking for one start–end interval on a single calendar day. The date must be today through one year ahead. The interval cannot cross midnight.
-_Avoid_: one-off as the canonical term, unbounded future dates, overnight or next-day as One-time
+A booking on a single calendar day. The date must be today through one year ahead. Each Booking line has its own start–end on that same day; lines cannot cross midnight. A booking with multiple lines cannot span more than one calendar day. One booking may include up to three lines, including more than one line for the same room at different times on that day.
+_Avoid_: one-off as the canonical term, unbounded future dates, overnight or next-day as One-time, a single shared time for every room in the booking, multi-room bookings across two calendar days
 
 **When**:
-The Start booking step for the One-time date and optional start and end. Date is required to continue. Start and end are either both empty or a complete pair; a single bound is invalid. They seed Search Bar Start Time and End Time and do not lock the Timetable.
-_Avoid_: treating start and end as required to Search, treating When as a date range, allowing only start or only end
+The Start booking step for the One-time date and optional start and end. Date is required to continue. Start and end are either both empty or a complete pair; a single bound is invalid. Start and end have no UI default; the member fills them or leaves both empty. When both are set, they drive When seed highlight on the Timetable; they are not shown on the Search Bar and do not add Booking lines.
+_Avoid_: treating start and end as required to Search, treating When as a date range, allowing only start or only end, putting When times on the Search Bar, prefilled or default start and end
+
+**When seed highlight**:
+On Timetable entry, when When has a complete start–end pair, every room that can cover that interval shows that span highlighted. It is not a Booking line and not in the Booking cart. Rooms that cannot cover the interval do not show this highlight. Other rooms keep their When seed highlight when the member Pinned interval on one room.
+_Avoid_: shared Booking interval, adding to the cart from When, highlighting Unavailable spans, clearing other rooms' seed when one room is clicked
 
 **Timetable**:
-The post-Search screen: rooms across the top, hours down the side, for one calendar day from 00:00 to 24:00. The route stays `/rooms`. On entry and after Update search, the grid scrolls to the Booking interval Start Time if that pair is set, otherwise to the earliest non-Closed Slot among visible rooms. Closed gray blocks stay on the axis; scrolling does not crop them.
-_Avoid_: Time Table, Calendar as this screen's name, Rooms as the member-facing screen name, cropping the day to open hours only
+The post-Search screen: rooms across the top, hours down the side, for one calendar day from 00:00 to 24:00, with a Booking cart panel on the right. The route stays `/rooms`. Open bookable hours use a light green background; Unavailable does not. Available blocks sit on top with a darker green fill, black border, and the left deep-green edge. On entry and after Update search, the grid scrolls to When start when set, otherwise to the earliest non-Closed Slot among visible rooms. Closed gray blocks stay on the axis; scrolling does not crop them.
+_Avoid_: Time Table, Calendar as this screen's name, Rooms as the member-facing screen name, cropping the day to open hours only, light green under Unavailable
 
 **Search Bar**:
-The editable summary of Start booking answers on the Timetable, in this order: Ministry, Repetition, Date, Start Time, End Time, # of rooms, plus Update search. Start Time and End Time together are the Booking interval, including a later Timetable pick that differs from When. The Ministry field is hidden unless the person is a Ministry member of at least one active ministry they can book for. When the field shows and the search is Non-ministry, it shows None and they may attach such a ministry. Holding the Owner position does not by itself show this field. Update search applies Search Bar changes (date, ministry, Single/Multiple, Room shortcut, and Start Time / End Time typed in the bar). BOOK and ADD still update Start Time and End Time immediately. Repetition stays One-time in this slice. Update search clears any selection that is not yet confirmed.
-_Avoid_: a read-only recap, treating When start–end as frozen after Search, showing Ministry for Owner position alone, treating pending-only applicants as able to attach a ministry, applying Search Bar fields without Update search, keeping a previous day's rooms after Update search, a single merged Time field as the Search Bar control, Date before Repetition
+The editable summary on the Timetable: Ministry (when shown), Repetition, Date, plus Update search. Controls are one size step larger than before. It does not show start time, end time, or room count. The Ministry field is hidden unless the person is a Ministry member of at least one active ministry they can book for. When the field shows and the search is Non-ministry, it shows None and they may attach such a ministry. Holding the Owner position does not by itself show this field. Update search applies date and ministry changes. Repetition stays One-time in this slice.
+_Avoid_: Start Time and End Time on the bar, # of rooms, Single/Multiple, Room shortcut, a read-only recap, showing Ministry for Owner position alone, treating pending-only applicants as able to attach a ministry
+
+**Booking cart**:
+The right-hand panel on the Timetable listing confirmed Booking lines after Confirm Booking Time. Review Booking sits at the top of this panel. Each line shows a room thumbnail, name, that line's time, line subtotal, Remove, and Edit. At most three lines per booking, including multiple lines for the same room at different times. Removing a line restores ADD on that Timetable block; Edit reopens Confirm Booking Time for that line.
+_Avoid_: cart on Booking Details as the primary picker, Review Booking only for Multiple, a single shared time for all lines
+
+**Booking line**:
+One room plus one start–end interval the member confirmed for a One-time booking, on the same calendar day as every other line in that booking. Lines live in the Booking cart before Review Booking and on Booking Details. The same room may appear on more than one line in one booking.
+_Avoid_: Booking interval as one span for all rooms, line without its own time, a line on a different calendar day from sibling lines in the same booking
+
+**Pinned interval**:
+The single-room span the member commits on the Timetable by clicking after hover preview, before ADD. It is not in the Booking cart until Confirm Booking Time succeeds. Clicking a room sets or changes only that room's Pinned interval; other rooms keep When seed highlight when present.
+_Avoid_: pinning all rooms from one click, treating pin as cart membership, BOOK
 
 **Booking Details**:
-The confirm page after Single Confirm Booking Time, or after Multiple Review Booking. The route is `/booking-details`. Date, Start Time, End Time, rooms, and ministry travel in the query as a draft snapshot, not a lock and not a cart. Each visit (including a pasted URL) reloads availability and Payment Summary from the backend. If any selected room cannot cover the Booking interval, Confirm stays disabled and the member can return to the Timetable. Confirm calls create booking; success goes to Payment. Create failure stays on this page. Date is that one calendar day. Each Space row has Edit and Remove: Remove drops that room (zero rooms returns to the Timetable); Edit returns to the Timetable with the current selection.
-_Avoid_: confirm modal as the product name, treating the query as a reservation, a shopping cart, treating Booking Details as a Timetable popup, treating the mock two-day date as the rule, a separate per-room edit mode, charging a card here
+The confirm page after Review Booking from the Booking cart. The route is `/booking-details`. A back control above the title returns to the Timetable with cart state preserved. Date, ministry, and Booking lines travel in the query as a draft snapshot, not a backend lock. Each visit reloads availability and Payment Summary. If any line is no longer available, Confirm stays disabled. Confirm calls create booking; success goes to Payment. There is no single Time row at the top; each Space row shows a thumbnail, that line's time, Edit, and Remove. Below all Space rows, + Room returns to the Timetable to add more lines.
+_Avoid_: a single shared Time field, confirm modal as the product name, treating the query as a paid reservation, skipping back to Timetable
 
 **Payment Summary**:
 The Booking Details aside that shows rate, ministry discount, tax, and total. The backend calculates the money; the client displays it.
@@ -113,35 +129,28 @@ The page after a successful create booking. The route uses the booking id. It sh
 _Avoid_: Confirm & Pay, a payment processor, treating this page as Booking Details, a second submit that marks the booking paid
 
 **Review Booking**:
-The Multiple-only Timetable CTA that opens the Booking Details page. The label includes how many rooms are selected. It is disabled until at least one room is added. Multiple allows one to three rooms.
-_Avoid_: Review Booking on Single, Review as the name of Booking Details, requiring two rooms for Multiple, opening Booking Details from ADD alone
-
-**Booking interval**:
-The single start–end all selected rooms share in one One-time booking. It is Search Bar Start Time and End Time, Confirm Booking Time, and Booking Details Time.
-_Avoid_: per-room times inside one One-time booking, a min–max span with a gap
+The Timetable CTA at the top of the Booking cart that opens Booking Details. It is disabled until at least one Booking line exists. The label reflects how many lines are in the cart.
+_Avoid_: Review as the name of Booking Details, Multiple-only, opening Booking Details directly from ADD without a cart line, BOOK
 
 **Confirm Booking Time**:
-The Single overlay after BOOK. It shows Date (the Search Bar date, not editable) plus Start Time and End Time. The member sets the Booking interval, then continues to the Booking Details page. It always opens on BOOK, including when Start Time and End Time are already filled.
-_Avoid_: Choose time, Booking Details as this overlay, skipping this overlay on Single when Time is already set, opening it from Multiple ADD, letting Date change here
-
-**BOOK**:
-The control on a Single Available block. It selects that room and always opens Confirm Booking Time. It does not open Booking Details or create the booking.
-_Avoid_: treating BOOK as Confirm, BOOK on Multiple, snapping empty-Time BOOK to the template's start_time chunk without Confirm Booking Time
+The modal opened by ADD on a Pinned interval. It shows Date (the Search Bar date, not editable) plus Start Time and End Time for that room line. On confirm, the line joins the Booking cart and the block control becomes a checkmark. Edit on a cart line reopens this modal for that line.
+_Avoid_: Choose time, Booking Details as this overlay, BOOK as the opener, skipping the modal, letting Date change here, checkmark opening the modal again
 
 **ADD**:
-The control on a Multiple Available block. It adds that room to the selection, at most three. With a Booking interval already set, Available means the room covers that whole interval and the interval is at least that room's Template duration; ADD does not change Start Time and End Time. With no Booking interval yet, ADD seeds Start Time and End Time from the clicked Slot start for exactly that room's Template duration. A later ADD on a different span replaces the shared Booking interval and keeps only that room. It does not open Confirm Booking Time, Booking Details, or create the booking.
-_Avoid_: BOOK as the Multiple block control, treating ADD as Confirm
+The control on an Available block after Pinned interval. It opens Confirm Booking Time. After a line is confirmed, ADD becomes a non-clickable checkmark on that block until the line is removed from the cart. Grid click alone only Pinned interval; it does not open this modal or add to the cart.
+_Avoid_: BOOK, treating grid click as ADD, checkmark as a second confirm, adding to the cart without the modal
 
 **Slot**:
 The Timetable visual time step: 30 minutes, all day. It is the ruler, not the bookable duration.
 _Avoid_: 60-minute cells as the member visual default
 
 **Template duration**:
-How long one empty-Time BOOK chunk is for that room that day: `slot_duration_minutes` on the room slot template. Open hours are the template start–end; Closed sits outside them (and on blackouts). A When / Search Bar interval must be at least this long for that room to be Available; it may be longer; it is not required to be an integer multiple.
-_Avoid_: using Template duration as the visual row height, requiring the Booking interval to align to template start_time, rejecting an interval equal to duration
+How long one hover-preview chunk is for that room that day: `slot_duration_minutes` on the room slot template. Open hours are the template start–end; Closed sits outside them (and on blackouts). A confirmed line must be at least this long for that room; it may be longer; it is not required to be an integer multiple.
+_Avoid_: using Template duration as the visual row height, requiring the line to align to template start_time, rejecting a line equal to duration
 
 **Available**:
-A Timetable span the member may BOOK or ADD. If Start Time and End Time are empty: hover (or a first tap on touch) previews a free chunk on that room only, starting at the Slot, length Template duration (and not crossing midnight); that preview is not a selection and does not paint other rooms. BOOK or ADD then commits that chunk as the Booking interval. If Start Time and End Time are set: the room is free for the whole Booking interval, and that interval is at least the room's Template duration; those rooms show Available without hover.
+A Timetable span shown as an Available block on which the member may ADD after Pinned interval. Hover (or a first tap on touch) previews a free chunk on that room only, starting at the Slot, length Template duration (and not crossing midnight); that preview is not a Pinned interval and does not paint other rooms. When seed highlight may show a wider span on eligible rooms without replacing per-room pin and cart rules.
+_Avoid_: BOOK, painting Available on every room from one action, treating hover preview as cart membership
 
 **Room photo**:
 The picture of a room on the Timetable column header. Opening it shows Image preview. If the room has no picture, the header shows a photo icon, not an image and not a text label.
@@ -160,7 +169,7 @@ A Timetable block that cannot be booked because the room is not open: outside th
 _Avoid_: outside hours, not open, gray as the name of the state, treating blackout as Unavailable
 
 **Override**:
-A Timetable block where this search is a Ministry booking with Ministry priority, and a Non-ministry booking holds the slot. Shown as its own state. This slice is display-only: no BOOK, no VIEW, no Confirm and notify.
+A Timetable block where this search is a Ministry booking with Ministry priority, and a Non-ministry booking holds the slot. Shown as its own state. This slice is display-only: no ADD, no VIEW, no Confirm and notify.
 _Avoid_: painting Override as Unavailable, showing Override on a Non-ministry search, treating VIEW as required to show the state
 
 **Available rooms**:
@@ -174,8 +183,8 @@ Timetable chips 1–10, 10–25, 25–50, 50+. Default is no chip (any capacity)
 _Avoid_: defaulting to 1–10, a free-form capacity box as the member Timetable control
 
 **No matching results**:
-The Available rooms view when no room can be BOOK'd under the current Search Bar, Booking interval, Template duration rule, and Capacity filter. All rooms still shows Closed / Unavailable / Override columns.
-_Avoid_: sending the member to Home, treating this as the whole building missing
+The Available rooms view when no room shows a bookable Available block under the current date, ministry, Template duration rule, and Capacity filter. All rooms still shows Closed / Unavailable / Override columns.
+_Avoid_: sending the member to Home, treating this as the whole building missing, BOOK
 
 **One-time window**:
 The allowed One-time date range: from today through one year ahead (rolling, not calendar year-end).
@@ -185,21 +194,13 @@ _Avoid_: calendar year, 365-day fee window as the name of this limit
 A booking frequency: the same interval on a repeating schedule (weekly, monthly). Member copy uses this word, not Recurring.
 _Avoid_: Reoccurring, Recurring (in member copy)
 
-**Space needed**:
-Single room or Multiple rooms — how many rooms this search is for. Gym and Sanctuary on that screen are Room shortcuts, not extra space values.
-_Avoid_: space=gym, space=sanctuary, room type taxonomy
-
-**Room shortcut**:
-Gym or Sanctuary chosen on the Space needed question. It names one specific room and still means Single room. Search Bar can change this later.
-_Avoid_: a third space value, facility category
-
 **Gym**:
-A named room. Choosing it as a Room shortcut means that room, with Space needed Single.
-_Avoid_: room type, facility type, excluding Gym from an unfiltered Single/Multiple search
+A named facility room code in the catalog. Members find it on the Timetable like any other room; there is no Start booking shortcut to Gym.
+_Avoid_: room type, facility type, Room shortcut, Space needed
 
 **Sanctuary**:
-A named room. Choosing it as a Room shortcut means that room, with Space needed Single.
-_Avoid_: room type, hall type, excluding Sanctuary from an unfiltered Single/Multiple search
+A named facility room code in the catalog. Members find it on the Timetable like any other room; there is no Start booking shortcut to Sanctuary.
+_Avoid_: room type, hall type, Room shortcut, Space needed
 
 **Ministry member**:
 A person listed on a ministry as primary or secondary steward. Pending, rejected, and active ministries all count for My Ministry. Only a Ministry member can see My Ministry. This is not the Owner position.

--- a/docs/adr/0003-space-and-room-query.md
+++ b/docs/adr/0003-space-and-room-query.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0024
+---
+
 # Space needed is single or multiple; Gym and Sanctuary are a room
 
 Search from Start booking sends `space=single` or `space=multiple` only. Choosing Gym or Sanctuary still sends `space=single` plus `room` as that room's stable code (`gym`, `sanctuary-hall`), because the Rooms Search Bar can change filters later. Missing `date` on Rooms returns to Home, not Start booking.

--- a/docs/adr/0005-review-booking-for-single-and-multiple.md
+++ b/docs/adr/0005-review-booking-for-single-and-multiple.md
@@ -1,5 +1,5 @@
 ---
-status: superseded by ADR-0015
+status: superseded by ADR-0022
 ---
 
 # Single and Multiple both open Booking Details via Review Booking

--- a/docs/adr/0006-when-time-optional-pair.md
+++ b/docs/adr/0006-when-time-optional-pair.md
@@ -1,3 +1,7 @@
+---
+status: updated by ADR-0025
+---
+
 # When start and end are optional, but only as a pair
 
 Start booking When requires a date in the One-time window. Start and end may both be empty so the member can pick a Booking interval on the Timetable. If either bound is present, both must be present. We do not treat a half-filled When as valid, and we do not keep the old rule that Search requires a complete time.

--- a/docs/adr/0007-shared-booking-interval.md
+++ b/docs/adr/0007-shared-booking-interval.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0022
+---
+
 # One One-time booking has one Booking interval
 
 Booking Details shows a single Time. Create booking allows per-room start and end, but a member One-time booking does not use that: every selected room shares one Booking interval. Choosing a different Available block changes that shared interval; it does not attach a second interval to a second room.

--- a/docs/adr/0013-update-search-clears-selection.md
+++ b/docs/adr/0013-update-search-clears-selection.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0024
+---
+
 # Update search applies the Search Bar and clears selection
 
 Typed Search Bar changes (date, ministry, space, room shortcut, Time) apply only on Update search. BOOK still writes Time immediately. This slice keeps Repetition on One-time. Update search drops rooms selected but not yet confirmed, so a new date or ministry cannot keep yesterday's Gym.

--- a/docs/adr/0015-single-confirm-booking-time.md
+++ b/docs/adr/0015-single-confirm-booking-time.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0023
+---
+
 # Single uses Confirm Booking Time; Multiple uses Review Booking
 
 ADR 0005 sent both Space needed modes through Review Booking so confirm was one path. We now follow the mocks: Single BOOK always opens Confirm Booking Time then the Booking Details page; Multiple uses ADD and Review Booking (n). One confirm page remains; the Timetable CTA differs so Single is not blocked behind a Review button that the mock does not have.

--- a/docs/adr/0016-booking-details-query-is-a-draft.md
+++ b/docs/adr/0016-booking-details-query-is-a-draft.md
@@ -1,3 +1,7 @@
+---
+status: updated by ADR-0027
+---
+
 # Booking Details is a page; the query is a draft, not a lock
 
 Booking Details is `/booking-details` with date, interval, rooms, and ministry in the query so reload and a pasted URL can reopen the same draft. That snapshot is not a cart and not a hold: every visit refetches availability and the backend quote, and create booking is the reservation. A query is shareable and easy to tamper; sessionStorage would hide the draft from a pasted URL but would not stop two tabs. We accept the query and make the server the source of truth.

--- a/docs/adr/0018-empty-time-available-is-hover-preview.md
+++ b/docs/adr/0018-empty-time-available-is-hover-preview.md
@@ -1,3 +1,7 @@
+---
+status: superseded by ADR-0023
+---
+
 # Empty Time Available is hover preview on one room
 
 When Start Time and End Time are empty, the Timetable does not paint Available on every room that could later cover a click. Hover (first tap on touch) previews Template duration on that column only. BOOK or ADD commits the Booking interval; only then do other rooms that cover it show Available. Painting all matching rooms on first click was confusing because it looked like a lock.

--- a/docs/adr/0022-booking-cart-per-room-lines.md
+++ b/docs/adr/0022-booking-cart-per-room-lines.md
@@ -1,0 +1,10 @@
+# Booking cart with per-room lines on one One-time booking
+
+Member One-time booking uses a **Booking cart** on the Timetable: up to three **Booking lines**, each with its own room and start–end on the **same calendar day** as every other line in that booking (no cross-day multi-room booking; no line crosses midnight). The same room may appear on more than one line at different times that day. **Review Booking** on the cart opens Booking Details; there is no Single/Multiple split and no shared Booking interval across lines.
+
+Supersedes ADR 0007. ADR 0005 and ADR 0015 are further superseded by ADR 0023.
+
+## Consequences
+
+- **newlife-core-api:** Drop or replace `uq_booking_room_booking_facility` so one booking may have multiple `booking_room` rows for the same `facility_id`. Member `preview-quote` must accept per-line `billed_hours` (ADR 0022 scope assumes Q26: quote after each line is confirmed).
+- **Cart line UI:** Thumbnail, room name, interval, line subtotal, Edit, Remove (see CONTEXT.md **Booking cart**).

--- a/docs/adr/0023-timetable-pin-add-confirm-flow.md
+++ b/docs/adr/0023-timetable-pin-add-confirm-flow.md
@@ -1,0 +1,10 @@
+# Timetable: hover preview, pin, ADD, then Confirm Booking Time
+
+On the Timetable, **hover** (or first tap on touch) previews Template duration on **one room column only**. **Click** sets that room’s **Pinned interval** only; it does not add to the cart or open a modal. **ADD** on the Available block opens **Confirm Booking Time**; on confirm the **Booking line** joins the cart and the control becomes a non-clickable checkmark until the line is removed from the cart. **BOOK** is retired. Edit on a cart line reopens the same modal.
+
+Supersedes ADR 0015 and ADR 0018.
+
+## Consequences
+
+- Grid click must not jump straight to Confirm Booking Time (prior Single BOOK behavior).
+- Remove from cart restores **ADD** on that block (checkmark is not an edit target).

--- a/docs/adr/0024-remove-space-needed-simplify-search-bar.md
+++ b/docs/adr/0024-remove-space-needed-simplify-search-bar.md
@@ -1,0 +1,5 @@
+# Remove Space needed; simplify Search Bar
+
+Start booking no longer asks **Space needed**; Gym and Sanctuary are found on the Timetable like any other room (no `space` or `room` shortcut on Search). The Timetable **Search Bar** shows Ministry (when applicable), Repetition, and Date only—one control size step larger than before—with **Update search**. It does not show start time, end time, or room count. Typed bar changes apply on Update search; the Booking cart is the source of selected lines, not Search Bar time fields.
+
+Supersedes ADR 0003. Replaces the selection-clearing rules in ADR 0013 for Time and space fields that no longer exist. **Update search** on **date** or **ministry** change clears the **Booking cart** so a new day cannot keep the previous day's lines.

--- a/docs/adr/0025-when-seed-highlight-no-defaults.md
+++ b/docs/adr/0025-when-seed-highlight-no-defaults.md
@@ -1,0 +1,9 @@
+# When optional time with no defaults; When seed highlight on Timetable
+
+Start booking **When** requires a date in the One-time window. Start and end remain **optional as a pair** (both empty or both set; half-filled is invalid). The UI **does not prefill** default start or end. When both are set, entering the Timetable paints **When seed highlight** on every room that can cover that interval; that highlight is not a Booking line and does not enter the cart. If When times are empty, no seed highlight is shown. When times are not shown on the Search Bar.
+
+Updates ADR 0006 (optional pair unchanged; adds no defaults and seed highlight semantics).
+
+## Consequences
+
+- Clicking one room sets **Pinned interval** for that column only; other rooms **keep** When seed highlight when present (ADR 0023).

--- a/docs/adr/0026-timetable-bookable-surface-visuals.md
+++ b/docs/adr/0026-timetable-bookable-surface-visuals.md
@@ -1,0 +1,3 @@
+# Timetable bookable surface: light green base and bordered Available blocks
+
+Within each room column, **open hours that are currently bookable** use a **lighter green** background than the **Available** block overlay. **Unavailable** spans inside open hours do not get the light green base. **Available** blocks (hover preview, Pinned interval, or When seed highlight where applicable) use a **darker green** fill, **black border**, and retain the **left deep-green** edge. **Closed** and **Override** styling follow ADR 0008 and ADR 0011.

--- a/docs/adr/0027-booking-details-from-cart.md
+++ b/docs/adr/0027-booking-details-from-cart.md
@@ -1,0 +1,5 @@
+# Booking Details follows the cart; back, thumbnails, and + Room
+
+**Booking Details** opens from **Review Booking** on the Booking cart, not from ADD alone. A **back** control above the title returns to the Timetable with cart state preserved. There is **no single Time row** at the top; each Space row shows a **thumbnail**, that line’s interval, Edit, and Remove. **+ Room** below all Space rows returns to the Timetable to add more lines. The URL query remains a **draft** snapshot (reload refetches availability and quote); it is not a backend hold.
+
+Updates ADR 0016 (draft query unchanged; cart is the Timetable-side selection model before Review Booking).

--- a/src/components/booking/StartBookingProgress.tsx
+++ b/src/components/booking/StartBookingProgress.tsx
@@ -7,7 +7,6 @@ const SEGMENTS: Array<{ step: StartBookingStep; labelKey: string }> = [
   { step: "select_ministry", labelKey: "startBooking.progress.ministryName" },
   { step: "frequency", labelKey: "startBooking.progress.howOften" },
   { step: "when", labelKey: "startBooking.progress.dateTime" },
-  { step: "space_needed", labelKey: "startBooking.progress.spaceNeeded" },
 ];
 
 interface StartBookingProgressProps {

--- a/src/i18n/locales/en/booking.json
+++ b/src/i18n/locales/en/booking.json
@@ -305,8 +305,7 @@
       "startBooking": "Start booking",
       "ministryName": "Ministry name",
       "howOften": "How often",
-      "dateTime": "Date & time",
-      "spaceNeeded": "Space needed"
+      "dateTime": "Date & time"
     },
     "ministryChoice": {
       "title": "To start, are you booking for a ministry?",
@@ -378,13 +377,6 @@
       "end": "End",
       "endPlaceholder": "Select end time",
       "endAfterStart": "End time must be after start time"
-    },
-    "spaceNeeded": {
-      "title": "Which room do you need?",
-      "single": "Single room",
-      "multiple": "Multiple rooms",
-      "gym": "Gym",
-      "sanctuary": "Sanctuary"
     },
     "errors": {
       "title": "Something went wrong",

--- a/src/i18n/locales/zh-CN/booking.json
+++ b/src/i18n/locales/zh-CN/booking.json
@@ -305,8 +305,7 @@
       "startBooking": "开始预订",
       "ministryName": "事工名称",
       "howOften": "频率",
-      "dateTime": "日期与时间",
-      "spaceNeeded": "所需空间"
+      "dateTime": "日期与时间"
     },
     "ministryChoice": {
       "title": "首先，这次是为事工预订吗？",
@@ -378,13 +377,6 @@
       "end": "结束",
       "endPlaceholder": "选择结束时间",
       "endAfterStart": "结束时间必须晚于开始时间"
-    },
-    "spaceNeeded": {
-      "title": "你需要哪个房间？",
-      "single": "单一房间",
-      "multiple": "多个房间",
-      "gym": "体育馆",
-      "sanctuary": "大堂"
     },
     "errors": {
       "title": "发生错误",

--- a/src/i18n/locales/zh-TW/booking.json
+++ b/src/i18n/locales/zh-TW/booking.json
@@ -305,8 +305,7 @@
       "startBooking": "開始預訂",
       "ministryName": "事工名稱",
       "howOften": "頻率",
-      "dateTime": "日期與時間",
-      "spaceNeeded": "所需空間"
+      "dateTime": "日期與時間"
     },
     "ministryChoice": {
       "title": "首先，這次是為事工預訂嗎？",
@@ -378,13 +377,6 @@
       "end": "結束",
       "endPlaceholder": "選擇結束時間",
       "endAfterStart": "結束時間必須晚於開始時間"
-    },
-    "spaceNeeded": {
-      "title": "你需要哪個房間？",
-      "single": "單一房間",
-      "multiple": "多個房間",
-      "gym": "體育館",
-      "sanctuary": "大堂"
     },
     "errors": {
       "title": "發生錯誤",

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -146,7 +146,8 @@ const RoomFilterPage = () => {
   const [draftDate, setDraftDate] = useState(initialQuery?.date ?? "");
   const [draftStart, setDraftStart] = useState(initialQuery?.start ?? "");
   const [draftEnd, setDraftEnd] = useState(initialQuery?.end ?? "");
-  const [draftSpace, setDraftSpace] = useState<RoomsSpace>(initialQuery?.space ?? "single");
+  const [draftSpace, setDraftSpace] = useState<RoomsSpace>("single");
+  const [appliedSpace, setAppliedSpace] = useState<RoomsSpace>("single");
   const [draftMinistryId, setDraftMinistryId] = useState(initialQuery?.ministryId ?? "");
   const [view, setView] = useState<TimetableView>("available");
   const [capacityBand, setCapacityBand] = useState<CapacityBand | null>(null);
@@ -174,8 +175,6 @@ const RoomFilterPage = () => {
   const appliedQuery = initialQuery;
   const appliedDate = appliedQuery?.date ?? "";
   const appliedMinistryId = appliedQuery?.ministryId;
-  const appliedSpace = appliedQuery?.space ?? "single";
-  const appliedRoom = appliedQuery?.room;
   const showMinistryField = bookableMinistries.length > 0;
   const minDate = moment().format("YYYY-MM-DD");
   const maxDate = moment().add(1, "year").format("YYYY-MM-DD");
@@ -228,10 +227,10 @@ const RoomFilterPage = () => {
   }, []);
 
   const listedRooms = useMemo(
-    () => visibleRooms(rooms, view, selection.interval, capacityBand, appliedRoom),
-    [appliedRoom, capacityBand, rooms, selection.interval, view]
+    () => visibleRooms(rooms, view, selection.interval, capacityBand, undefined),
+    [capacityBand, rooms, selection.interval, view]
   );
-  const noMatching = hasNoMatchingResults(rooms, view, selection.interval, capacityBand, appliedRoom);
+  const noMatching = hasNoMatchingResults(rooms, view, selection.interval, capacityBand, undefined);
   const isInitialLoad = isTimetableInitialLoad(loading, rooms.length);
   const showNoMatching = noMatching && !isInitialLoad;
   const pageCount = Math.max(1, Math.ceil(listedRooms.length / ROOMS_PER_PAGE));
@@ -244,7 +243,7 @@ const RoomFilterPage = () => {
 
   useEffect(() => {
     setPageIndex(0);
-  }, [view, capacityBand, appliedRoom, appliedDate, listedRooms.length]);
+  }, [view, capacityBand, appliedDate, listedRooms.length]);
 
   const appliedStart = appliedQuery?.start;
   const appliedEnd = appliedQuery?.end;
@@ -254,10 +253,10 @@ const RoomFilterPage = () => {
       return;
     }
     const interval = appliedStart && appliedEnd ? { start: appliedStart, end: appliedEnd } : null;
-    if (hasNoMatchingResults(rooms, view, interval, capacityBand, appliedRoom)) {
+    if (hasNoMatchingResults(rooms, view, interval, capacityBand, undefined)) {
       return;
     }
-    const roomsForScroll = visibleRooms(rooms, view, interval, capacityBand, appliedRoom);
+    const roomsForScroll = visibleRooms(rooms, view, interval, capacityBand, undefined);
     const scroller = gridScrollRef.current;
     if (!scroller) {
       return;
@@ -269,7 +268,7 @@ const RoomFilterPage = () => {
       top,
       behavior: prefersReducedMotion ? "auto" : "smooth",
     });
-  }, [appliedDate, appliedEnd, appliedRoom, appliedStart, capacityBand, loading, rooms, view]);
+  }, [appliedDate, appliedEnd, appliedStart, capacityBand, loading, rooms, view]);
 
   const handleUpdateSearch = useCallback(() => {
     if (loading) {
@@ -289,7 +288,6 @@ const RoomFilterPage = () => {
     }
     const next: RoomsSearchQuery = {
       date: draftDate,
-      space: draftSpace,
     };
     if (draftStart && draftEnd) {
       next.start = draftStart;
@@ -298,10 +296,8 @@ const RoomFilterPage = () => {
     if (draftMinistryId) {
       next.ministryId = draftMinistryId;
     }
-    if (appliedRoom) {
-      next.room = appliedRoom;
-    }
     setSearchParams(toRoomsSearchParams(next), { replace: true });
+    setAppliedSpace(draftSpace);
     setHover(null);
     setSelection(
       clearUnconfirmedSelection({
@@ -310,18 +306,7 @@ const RoomFilterPage = () => {
       })
     );
     setError(null);
-  }, [
-    appliedRoom,
-    draftDate,
-    draftEnd,
-    draftMinistryId,
-    draftSpace,
-    draftStart,
-    loading,
-    selection.roomIds,
-    setSearchParams,
-    t,
-  ]);
+  }, [draftDate, draftEnd, draftMinistryId, draftSpace, draftStart, loading, selection.roomIds, setSearchParams, t]);
 
   useEffect(() => {
     const on_pointer_down = (event: PointerEvent) => {
@@ -400,7 +385,6 @@ const RoomFilterPage = () => {
         space: appliedSpace,
         roomIds: [confirmRoom.id],
         ...(appliedMinistryId ? { ministryId: appliedMinistryId } : {}),
-        ...(appliedRoom ? { room: appliedRoom } : {}),
       }).toString(),
     });
   };
@@ -445,7 +429,6 @@ const RoomFilterPage = () => {
         space: appliedSpace,
         roomIds: selection.roomIds,
         ...(appliedMinistryId ? { ministryId: appliedMinistryId } : {}),
-        ...(appliedRoom ? { room: appliedRoom } : {}),
       }).toString(),
     });
   };

--- a/src/pages/start-booking/StartBookingPage.tsx
+++ b/src/pages/start-booking/StartBookingPage.tsx
@@ -13,7 +13,6 @@ import {
   previousStep,
   toRoomsSearchParams,
   type BookingFrequency,
-  type SpaceNeededChoice,
   type StartBookingAnswers,
   type StartBookingStep,
 } from "@/utils/startBookingFlow";
@@ -66,7 +65,6 @@ const StartBookingPage = () => {
   const [dateValue, setDateValue] = useState<DatePickerValue>(null);
   const [startValue, setStartValue] = useState<TimePickerValue>(null);
   const [endValue, setEndValue] = useState<TimePickerValue>(null);
-  const [space, setSpace] = useState<SpaceNeededChoice | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,7 +83,6 @@ const StartBookingPage = () => {
     ministryId,
     frequency,
     when,
-    space,
   };
   const canGoForward = canAdvance(step, answers, now);
   const endTimeError = isWhenEndAfterStart(when) ? undefined : t("startBooking.when.endAfterStart");
@@ -169,7 +166,7 @@ const StartBookingPage = () => {
     }
   };
 
-  const continueLabel = step === "space_needed" ? t("startBooking.search") : t("startBooking.continue");
+  const continueLabel = step === "when" ? t("startBooking.search") : t("startBooking.continue");
 
   return (
     <main className="mx-auto flex w-full max-w-[960px] flex-1 flex-col items-center px-6 py-8 sm:px-8">
@@ -318,50 +315,6 @@ const StartBookingPage = () => {
                 value={endValue}
               />
             </div>
-          </div>
-        </section>
-      ) : null}
-
-      {step === "space_needed" ? (
-        <section className="mt-10 flex w-full flex-col items-center">
-          <h1 className="text-center text-4xl font-semibold text-on-surface">{t("startBooking.spaceNeeded.title")}</h1>
-          <div className="mt-8 grid w-full grid-cols-2 gap-4">
-            <ChoicePill
-              checked={space === "single"}
-              id="space-single"
-              label={t("startBooking.spaceNeeded.single")}
-              name="space"
-              onChange={() => setSpace("single")}
-              value="single"
-              wide
-            />
-            <ChoicePill
-              checked={space === "multiple"}
-              id="space-multiple"
-              label={t("startBooking.spaceNeeded.multiple")}
-              name="space"
-              onChange={() => setSpace("multiple")}
-              value="multiple"
-              wide
-            />
-            <ChoicePill
-              checked={space === "gym"}
-              id="space-gym"
-              label={t("startBooking.spaceNeeded.gym")}
-              name="space"
-              onChange={() => setSpace("gym")}
-              value="gym"
-              wide
-            />
-            <ChoicePill
-              checked={space === "sanctuary"}
-              id="space-sanctuary"
-              label={t("startBooking.spaceNeeded.sanctuary")}
-              name="space"
-              onChange={() => setSpace("sanctuary")}
-              value="sanctuary"
-              wide
-            />
           </div>
         </section>
       ) : null}

--- a/src/utils/startBookingFlow.test.ts
+++ b/src/utils/startBookingFlow.test.ts
@@ -22,22 +22,21 @@ const answers = (overrides: Partial<StartBookingAnswers> = {}): StartBookingAnsw
     isMinistryBooking: null,
     ministryId: null,
     frequency: null,
-    space: null,
     ...rest,
     when: { ...blankWhen, ...whenOverride },
   };
 };
 
 describe("isStartBookingStep", () => {
-  it("accepts the five Start booking questions", () => {
+  it("accepts the four Start booking questions", () => {
     expect(isStartBookingStep("ministry_choice")).toBe(true);
     expect(isStartBookingStep("select_ministry")).toBe(true);
     expect(isStartBookingStep("frequency")).toBe(true);
     expect(isStartBookingStep("when")).toBe(true);
-    expect(isStartBookingStep("space_needed")).toBe(true);
   });
 
-  it("rejects the old Find Space steps", () => {
+  it("rejects removed or legacy steps", () => {
+    expect(isStartBookingStep("space_needed")).toBe(false);
     expect(isStartBookingStep("select_date")).toBe(false);
     expect(isStartBookingStep("create_ministry")).toBe(false);
     expect(isStartBookingStep("pending_approval")).toBe(false);
@@ -72,22 +71,16 @@ describe("nextStep", () => {
     expect(nextStep("frequency", answers({ frequency: "repeated" }))).toBe(null);
   });
 
-  it("goes from a date-only When to Space needed", () => {
+  it("goes from a date-only When to the Timetable", () => {
     const now = new Date("2026-08-13T12:00:00");
-    expect(nextStep("when", answers({ when: { date: "2026-08-20", start: null, end: null } }), now)).toBe(
-      "space_needed"
-    );
+    expect(nextStep("when", answers({ when: { date: "2026-08-20", start: null, end: null } }), now)).toBe("rooms");
   });
 
-  it("goes from a valid When to Space needed", () => {
+  it("goes from a valid When to the Timetable", () => {
     const now = new Date("2026-08-13T12:00:00");
     expect(nextStep("when", answers({ when: { date: "2026-08-20", start: "09:00", end: "11:00" } }), now)).toBe(
-      "space_needed"
+      "rooms"
     );
-  });
-
-  it("leaves Start booking for Rooms after Space needed", () => {
-    expect(nextStep("space_needed", answers({ space: "single" }))).toBe("rooms");
   });
 });
 
@@ -111,10 +104,6 @@ describe("previousStep", () => {
   it("returns frequency from date and time", () => {
     expect(previousStep("when", answers({ frequency: "one_time" }))).toBe("frequency");
   });
-
-  it("returns date and time from Space needed", () => {
-    expect(previousStep("space_needed", answers({ space: "single" }))).toBe("when");
-  });
 });
 
 describe("canAdvance", () => {
@@ -135,9 +124,12 @@ describe("canAdvance", () => {
     expect(canAdvance("frequency", answers())).toBe(false);
   });
 
-  it("allows Search only when Space needed is chosen", () => {
-    expect(canAdvance("space_needed", answers())).toBe(false);
-    expect(canAdvance("space_needed", answers({ space: "gym" }))).toBe(true);
+  it("allows Search on When only when the date and optional time pair are valid", () => {
+    const now = new Date("2026-08-13T12:00:00");
+    expect(canAdvance("when", answers(), now)).toBe(false);
+    expect(canAdvance("when", answers({ when: { date: "2026-08-20", start: null, end: null } }), now)).toBe(true);
+    expect(canAdvance("when", answers({ when: { date: "2026-08-20", start: "09:00", end: "11:00" } }), now)).toBe(true);
+    expect(canAdvance("when", answers({ when: { date: "2026-08-20", start: "09:00", end: null } }), now)).toBe(false);
   });
 });
 
@@ -203,66 +195,30 @@ describe("isWhenValid", () => {
 describe("buildRoomsSearchQuery", () => {
   const when = { date: "2026-09-01", start: "09:00", end: "11:00" };
 
-  it("sends space=single without a room code for Single room", () => {
-    expect(buildRoomsSearchQuery(answers({ when, space: "single" }))).toEqual({
+  it("sends date and optional start/end without space or room shortcut params", () => {
+    expect(buildRoomsSearchQuery(answers({ when }))).toEqual({
       date: "2026-09-01",
       start: "09:00",
       end: "11:00",
-      space: "single",
-    });
-  });
-
-  it("sends space=multiple without a room code for Multiple rooms", () => {
-    expect(buildRoomsSearchQuery(answers({ when, space: "multiple" }))).toEqual({
-      date: "2026-09-01",
-      start: "09:00",
-      end: "11:00",
-      space: "multiple",
-    });
-  });
-
-  it("sends space=single and room=gym for the Gym shortcut", () => {
-    expect(buildRoomsSearchQuery(answers({ when, space: "gym" }))).toEqual({
-      date: "2026-09-01",
-      start: "09:00",
-      end: "11:00",
-      space: "single",
-      room: "gym",
-    });
-  });
-
-  it("sends space=single and room=sanctuary-hall for the Sanctuary shortcut", () => {
-    expect(buildRoomsSearchQuery(answers({ when, space: "sanctuary" }))).toEqual({
-      date: "2026-09-01",
-      start: "09:00",
-      end: "11:00",
-      space: "single",
-      room: "sanctuary-hall",
     });
   });
 
   it("includes ministryId only for a Ministry booking", () => {
-    expect(
-      buildRoomsSearchQuery(answers({ isMinistryBooking: true, ministryId: "m-1", when, space: "single" }))
-    ).toEqual({
+    expect(buildRoomsSearchQuery(answers({ isMinistryBooking: true, ministryId: "m-1", when }))).toEqual({
       date: "2026-09-01",
       start: "09:00",
       end: "11:00",
-      space: "single",
       ministryId: "m-1",
     });
-    expect(
-      buildRoomsSearchQuery(answers({ isMinistryBooking: false, ministryId: "m-1", when, space: "single" }))
-    ).toEqual({
+    expect(buildRoomsSearchQuery(answers({ isMinistryBooking: false, ministryId: "m-1", when }))).toEqual({
       date: "2026-09-01",
       start: "09:00",
       end: "11:00",
-      space: "single",
     });
   });
 
   it("does not put minHours or multiRoom on the Search query", () => {
-    const query = buildRoomsSearchQuery(answers({ when, space: "multiple" }));
+    const query = buildRoomsSearchQuery(answers({ when }));
     expect(query).not.toBeNull();
     if (!query) {
       return;
@@ -272,20 +228,19 @@ describe("buildRoomsSearchQuery", () => {
     const params = toRoomsSearchParams(query);
     expect(params.has("minHours")).toBe(false);
     expect(params.has("multiRoom")).toBe(false);
+    expect(params.has("space")).toBe(false);
+    expect(params.has("room")).toBe(false);
   });
 
-  it("sends optional start and end when When is date-only", () => {
-    expect(
-      buildRoomsSearchQuery(answers({ when: { date: "2026-09-01", start: null, end: null }, space: "single" }))
-    ).toEqual({
+  it("omits start and end when When is date-only", () => {
+    expect(buildRoomsSearchQuery(answers({ when: { date: "2026-09-01", start: null, end: null } }))).toEqual({
       date: "2026-09-01",
-      space: "single",
     });
   });
 
-  it("returns null when When or Space needed is incomplete", () => {
-    expect(buildRoomsSearchQuery(answers({ when, space: null }))).toBe(null);
-    expect(buildRoomsSearchQuery(answers({ space: "single" }))).toBe(null);
+  it("returns null when When is incomplete", () => {
+    expect(buildRoomsSearchQuery(answers({ when: { date: null, start: null, end: null } }))).toBe(null);
+    expect(buildRoomsSearchQuery(answers({ when: { date: "2026-09-01", start: "09:00", end: null } }))).toBe(null);
   });
 });
 
@@ -296,7 +251,7 @@ describe("parseRoomsSearchQuery", () => {
     expect(parseRoomsSearchQuery(new URLSearchParams("date=not-a-date"))).toBe(null);
   });
 
-  it("reads the new Search contract and ignores extra keys", () => {
+  it("reads date, optional interval, and ministry while ignoring legacy keys", () => {
     const params = new URLSearchParams(
       "date=2026-09-01&start=09:00&end=11:00&space=single&room=gym&ministryId=m-1&minHours=2&multiRoom=1"
     );
@@ -304,8 +259,6 @@ describe("parseRoomsSearchQuery", () => {
       date: "2026-09-01",
       start: "09:00",
       end: "11:00",
-      space: "single",
-      room: "gym",
       ministryId: "m-1",
     });
   });
@@ -313,7 +266,6 @@ describe("parseRoomsSearchQuery", () => {
   it("drops a half-filled Time pair and keeps the date", () => {
     expect(parseRoomsSearchQuery(new URLSearchParams("date=2026-09-01&start=09:00&space=single"))).toEqual({
       date: "2026-09-01",
-      space: "single",
     });
   });
 });
@@ -328,7 +280,7 @@ describe("parseBookingDetailsQuery", () => {
     expect(parseBookingDetailsQuery(new URLSearchParams("start=09:00&end=11:00&rooms=room-a&space=single"))).toBe(null);
   });
 
-  it("reads a draft snapshot of date, interval, rooms, space, and ministry", () => {
+  it("reads a draft snapshot of date, interval, rooms, and ministry", () => {
     const params = new URLSearchParams(
       "date=2026-09-01&start=09:00&end=11:00&space=multiple&rooms=room-a,room-b&ministryId=m-1&room=gym"
     );
@@ -362,7 +314,6 @@ describe("toBookingDetailsSearchParams", () => {
       date: "2026-09-01",
       start: "10:00",
       end: "11:30",
-      space: "single" as const,
       roomIds: ["room-a"],
       ministryId: "m-1",
     };

--- a/src/utils/startBookingFlow.ts
+++ b/src/utils/startBookingFlow.ts
@@ -1,12 +1,10 @@
 import moment from "moment";
 
-export const START_BOOKING_STEPS = ["ministry_choice", "select_ministry", "frequency", "when", "space_needed"] as const;
+export const START_BOOKING_STEPS = ["ministry_choice", "select_ministry", "frequency", "when"] as const;
 
 export type StartBookingStep = (typeof START_BOOKING_STEPS)[number];
 
 export type BookingFrequency = "one_time" | "repeated";
-
-export type SpaceNeededChoice = "single" | "multiple" | "gym" | "sanctuary";
 
 export type RoomsSpace = "single" | "multiple";
 
@@ -23,26 +21,18 @@ export interface StartBookingAnswers {
   ministryId: string | null;
   frequency: BookingFrequency | null;
   when: WhenValue;
-  space: SpaceNeededChoice | null;
 }
 
 export interface RoomsSearchQuery {
   date: string;
   start?: string;
   end?: string;
-  space: RoomsSpace;
   ministryId?: string;
-  room?: RoomShortcutCode;
 }
 
 const DATE_FORMAT = "YYYY-MM-DD";
 const TIME_FORMAT = "HH:mm";
 const DATE_TIME_FORMAT = "YYYY-MM-DD HH:mm";
-
-const ROOM_SHORTCUT_CODES: Record<"gym" | "sanctuary", RoomShortcutCode> = {
-  gym: "gym",
-  sanctuary: "sanctuary-hall",
-};
 
 export const isStartBookingStep = (value: string | null): value is StartBookingStep => {
   return START_BOOKING_STEPS.some((step) => step === value);
@@ -112,8 +102,6 @@ export const canAdvance = (step: StartBookingStep, answers: StartBookingAnswers,
       return answers.frequency === "one_time";
     case "when":
       return isWhenValid(answers.when, now);
-    case "space_needed":
-      return answers.space != null;
   }
 };
 
@@ -133,8 +121,6 @@ export const nextStep = (
     case "frequency":
       return "when";
     case "when":
-      return "space_needed";
-    case "space_needed":
       return "rooms";
   }
 };
@@ -149,13 +135,11 @@ export const previousStep = (step: StartBookingStep, answers: StartBookingAnswer
       return answers.isMinistryBooking ? "select_ministry" : "ministry_choice";
     case "when":
       return "frequency";
-    case "space_needed":
-      return "when";
   }
 };
 
 export const buildRoomsSearchQuery = (answers: StartBookingAnswers): RoomsSearchQuery | null => {
-  if (!answers.when.date || answers.space == null) {
+  if (!answers.when.date) {
     return null;
   }
   if (hasHalfFilledTime(answers.when)) {
@@ -164,7 +148,6 @@ export const buildRoomsSearchQuery = (answers: StartBookingAnswers): RoomsSearch
 
   const query: RoomsSearchQuery = {
     date: answers.when.date,
-    space: answers.space === "multiple" ? "multiple" : "single",
   };
 
   if (answers.when.start && answers.when.end) {
@@ -174,10 +157,6 @@ export const buildRoomsSearchQuery = (answers: StartBookingAnswers): RoomsSearch
 
   if (answers.isMinistryBooking && answers.ministryId) {
     query.ministryId = answers.ministryId;
-  }
-
-  if (answers.space === "gym" || answers.space === "sanctuary") {
-    query.room = ROOM_SHORTCUT_CODES[answers.space];
   }
 
   return query;
@@ -198,22 +177,15 @@ export const parseRoomsSearchQuery = (params: URLSearchParams): RoomsSearchQuery
 
   const start = parseTimeOfDay(params.get("start"));
   const end = parseTimeOfDay(params.get("end"));
-  const space: RoomsSpace = params.get("space") === "multiple" ? "multiple" : "single";
-  const roomParam = params.get("room");
-  const room: RoomShortcutCode | undefined =
-    roomParam === "gym" || roomParam === "sanctuary-hall" ? roomParam : undefined;
   const ministryId = params.get("ministryId") || undefined;
 
-  const query: RoomsSearchQuery = { date, space };
+  const query: RoomsSearchQuery = { date };
   if (start && end && isWhenEndAfterStart({ date, start, end })) {
     query.start = start;
     query.end = end;
   }
   if (ministryId) {
     query.ministryId = ministryId;
-  }
-  if (room) {
-    query.room = room;
   }
   return query;
 };
@@ -227,12 +199,8 @@ export const toRoomsSearchParams = (query: RoomsSearchQuery): URLSearchParams =>
   if (query.end) {
     params.set("end", query.end);
   }
-  params.set("space", query.space);
   if (query.ministryId) {
     params.set("ministryId", query.ministryId);
-  }
-  if (query.room) {
-    params.set("room", query.room);
   }
   return params;
 };
@@ -241,6 +209,10 @@ export interface BookingDetailsQuery extends RoomsSearchQuery {
   start: string;
   end: string;
   roomIds: string[];
+  /** Legacy URL param; ignored for new Timetable navigation. */
+  space?: RoomsSpace;
+  /** Legacy room shortcut; ignored for new Timetable navigation. */
+  room?: RoomShortcutCode;
 }
 
 const MAX_BOOKING_DETAIL_ROOMS = 3;
@@ -257,6 +229,25 @@ const parseRoomIdsParam = (params: URLSearchParams): string[] => {
     .slice(0, MAX_BOOKING_DETAIL_ROOMS);
 };
 
+const parseLegacySpace = (params: URLSearchParams): RoomsSpace | undefined => {
+  const space = params.get("space");
+  if (space === "multiple") {
+    return "multiple";
+  }
+  if (space === "single") {
+    return "single";
+  }
+  return undefined;
+};
+
+const parseLegacyRoomShortcut = (params: URLSearchParams): RoomShortcutCode | undefined => {
+  const roomParam = params.get("room");
+  if (roomParam === "gym" || roomParam === "sanctuary-hall") {
+    return roomParam;
+  }
+  return undefined;
+};
+
 export const parseBookingDetailsQuery = (params: URLSearchParams): BookingDetailsQuery | null => {
   const search = parseRoomsSearchQuery(params);
   if (!search?.start || !search.end) {
@@ -266,16 +257,32 @@ export const parseBookingDetailsQuery = (params: URLSearchParams): BookingDetail
   if (roomIds.length === 0) {
     return null;
   }
+  const legacy: Pick<BookingDetailsQuery, "space" | "room"> = {};
+  const space = parseLegacySpace(params);
+  if (space) {
+    legacy.space = space;
+  }
+  const room = parseLegacyRoomShortcut(params);
+  if (room) {
+    legacy.room = room;
+  }
   return {
     ...search,
     start: search.start,
     end: search.end,
     roomIds,
+    ...legacy,
   };
 };
 
 export const toBookingDetailsSearchParams = (query: BookingDetailsQuery): URLSearchParams => {
   const params = toRoomsSearchParams(query);
   params.set("rooms", query.roomIds.join(","));
+  if (query.space) {
+    params.set("space", query.space);
+  }
+  if (query.room) {
+    params.set("room", query.room);
+  }
   return params;
 };


### PR DESCRIPTION
## Summary

Remove the **Space needed** step from Start booking so members go directly from **When** to the Timetable. Navigation to `/rooms` now sends `date` with optional `start`/`end` and `ministryId` only—no `space` or Gym/Sanctuary shortcut params. Also records timetable cart ADRs and CONTEXT updates for the parent epic (#68).

Closes #70

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [x] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `startBookingFlow` helpers and tests updated; legacy `space`/`room` URL params are ignored on Timetable entry but still parsed for Booking Details deep links.
- Timetable Search Bar simplification (remove start/end and room-count fields) is tracked separately under ADR 0024 / follow-up issues—not in this PR.

## Testing

- [x] `pnpm type-check`
- [x] `pnpm test`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)