### PR TITLE
feat: Timetable cart domain rules and multi-line draft encoding

### DIFF
--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -14,30 +14,32 @@ import {
   type RoomsSpace,
 } from "@/utils/startBookingFlow";
 import {
-  bookRoom,
-  canReviewBooking,
-  clearUnconfirmedSelection,
   clockToMinutes,
   confirmBookingTimePrefill,
   displayBlocks,
   emptyTimeBookInterval,
   emptyTimePointerAction,
-  hasNoMatchingResults,
   isBookableCell,
   isTimetableInitialLoad,
   minutesToClock,
   scrollTargetClock,
   SLOT_MINUTES,
-  visibleRooms,
   type BookingInterval,
   type CapacityBand,
   type CellState,
   type HoverPreview,
   type PointerKind,
   type RoomDay,
-  type TimetableSelection,
   type TimetableView,
 } from "@/utils/timetableRules";
+import {
+  bookRoom,
+  canReviewBooking,
+  clearUnconfirmedSelection,
+  hasNoMatchingResultsLegacy as hasNoMatchingResults,
+  type TimetableSelection,
+  visibleRoomsLegacy as visibleRooms,
+} from "@/utils/timetableRulesLegacy";
 import {
   Alert,
   Badge,

--- a/src/utils/bookingCartDraft.test.ts
+++ b/src/utils/bookingCartDraft.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { emptyCartState } from "./timetableRules";
+import {
+  cartStateToDraft,
+  draftToCartState,
+  parseBookingCartDraft,
+  toBookingCartDraftParams,
+  whenSeedFromSearch,
+} from "./bookingCartDraft";
+
+describe("whenSeedFromSearch", () => {
+  it("returns null unless both start and end are present and valid", () => {
+    expect(whenSeedFromSearch(undefined, undefined)).toBeNull();
+    expect(whenSeedFromSearch("09:00", undefined)).toBeNull();
+    expect(whenSeedFromSearch("09:00", "11:00")).toEqual({ start: "09:00", end: "11:00" });
+  });
+});
+
+describe("parseBookingCartDraft", () => {
+  it("returns null when date or lines are missing", () => {
+    expect(parseBookingCartDraft(new URLSearchParams())).toBeNull();
+    expect(parseBookingCartDraft(new URLSearchParams("date=2026-09-01"))).toBeNull();
+    expect(parseBookingCartDraft(new URLSearchParams("date=bad-date&lines=1~room-a~10:00~11:00"))).toBeNull();
+  });
+
+  it("reads multi-line drafts with facilityId, start, end, and sequence", () => {
+    const params = new URLSearchParams(
+      "date=2026-09-01&lines=1~room-a~10:00~11:00,2~room-b~14:00~15:00&ministryId=m-1"
+    );
+    expect(parseBookingCartDraft(params)).toEqual({
+      date: "2026-09-01",
+      ministryId: "m-1",
+      lines: [
+        { sequence: 1, facilityId: "room-a", start: "10:00", end: "11:00" },
+        { sequence: 2, facilityId: "room-b", start: "14:00", end: "15:00" },
+      ],
+    });
+  });
+
+  it("drops duplicate lines and caps at three", () => {
+    const params = new URLSearchParams(
+      "date=2026-09-01&lines=1~room-a~10:00~11:00,2~room-a~10:00~11:00,3~room-b~12:00~13:00,4~room-c~13:00~14:00,5~room-d~14:00~15:00"
+    );
+    expect(parseBookingCartDraft(params)?.lines).toHaveLength(3);
+  });
+});
+
+describe("toBookingCartDraftParams", () => {
+  it("round-trips a multi-line draft", () => {
+    const draft = {
+      date: "2026-09-01",
+      ministryId: "m-1",
+      lines: [
+        { sequence: 2, facilityId: "room-b", start: "14:00", end: "15:00" },
+        { sequence: 1, facilityId: "room-a", start: "10:00", end: "11:00" },
+      ],
+    };
+    expect(parseBookingCartDraft(toBookingCartDraftParams(draft))).toEqual({
+      date: "2026-09-01",
+      ministryId: "m-1",
+      lines: [
+        { sequence: 1, facilityId: "room-a", start: "10:00", end: "11:00" },
+        { sequence: 2, facilityId: "room-b", start: "14:00", end: "15:00" },
+      ],
+    });
+  });
+});
+
+describe("cartStateToDraft", () => {
+  it("encodes confirmed cart lines for Booking Details navigation", () => {
+    const state = {
+      ...emptyCartState({ start: "09:00", end: "11:00" }),
+      lines: [
+        { facilityId: "room-a", start: "10:00", end: "11:00", sequence: 1 },
+        { facilityId: "room-a", start: "14:00", end: "15:00", sequence: 2 },
+      ],
+    };
+    expect(cartStateToDraft("2026-09-01", "m-1", state)).toEqual({
+      date: "2026-09-01",
+      ministryId: "m-1",
+      lines: state.lines,
+    });
+  });
+});
+
+describe("draftToCartState", () => {
+  it("restores cart lines and optional When seed without pin", () => {
+    const draft = {
+      date: "2026-09-01",
+      lines: [{ sequence: 1, facilityId: "room-a", start: "10:00", end: "11:00" }],
+    };
+    const whenSeed = { start: "09:00", end: "11:00" };
+    expect(draftToCartState(draft, whenSeed)).toEqual({
+      lines: [{ facilityId: "room-a", start: "10:00", end: "11:00", sequence: 1 }],
+      pinned: null,
+      whenSeed,
+    });
+  });
+});

--- a/src/utils/bookingCartDraft.ts
+++ b/src/utils/bookingCartDraft.ts
@@ -1,0 +1,156 @@
+import moment from "moment";
+
+import { intervalStaysOnSameDay, MAX_BOOKING_LINES, type WhenSeedRange } from "./timetableRules";
+import type { BookingLine, TimetableCartState } from "./timetableRules";
+
+const DATE_FORMAT = "YYYY-MM-DD";
+const TIME_FORMAT = "HH:mm";
+const FIELD_SEP = "~";
+const LINE_SEP = ",";
+
+export interface BookingLineDraft {
+  facilityId: string;
+  start: string;
+  end: string;
+  sequence: number;
+}
+
+export interface BookingCartDraft {
+  date: string;
+  ministryId?: string;
+  lines: BookingLineDraft[];
+}
+
+const isClock = (value: string): boolean => moment(value, TIME_FORMAT, true).isValid() || value === "24:00";
+
+const encodeLine = (line: BookingLineDraft): string => {
+  return [line.sequence, line.facilityId, line.start, line.end].join(FIELD_SEP);
+};
+
+const decodeLine = (raw: string): BookingLineDraft | null => {
+  const parts = raw.split(FIELD_SEP);
+  if (parts.length !== 4) {
+    return null;
+  }
+  const sequence = Number.parseInt(parts[0], 10);
+  const facilityId = parts[1];
+  const start = parts[2];
+  const end = parts[3];
+  if (!Number.isFinite(sequence) || sequence < 1 || !facilityId || !isClock(start) || !isClock(end)) {
+    return null;
+  }
+  if (!intervalStaysOnSameDay({ start, end })) {
+    return null;
+  }
+  return { sequence, facilityId, start, end };
+};
+
+const parseLinesParam = (raw: string | null): BookingLineDraft[] => {
+  if (!raw) {
+    return [];
+  }
+  const lines: BookingLineDraft[] = [];
+  const seen = new Set<string>();
+  for (const segment of raw.split(LINE_SEP)) {
+    const trimmed = segment.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const line = decodeLine(trimmed);
+    if (!line) {
+      continue;
+    }
+    const key = `${line.facilityId}\0${line.start}\0${line.end}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    lines.push(line);
+    if (lines.length >= MAX_BOOKING_LINES) {
+      break;
+    }
+  }
+  return lines.sort((left, right) => left.sequence - right.sequence);
+};
+
+export const whenSeedFromSearch = (start?: string, end?: string): WhenSeedRange | null => {
+  if (!start || !end || !isClock(start) || !isClock(end)) {
+    return null;
+  }
+  if (!intervalStaysOnSameDay({ start, end })) {
+    return null;
+  }
+  return { start, end };
+};
+
+export const parseBookingCartDraft = (params: URLSearchParams): BookingCartDraft | null => {
+  const date = params.get("date");
+  if (!date || !moment(date, DATE_FORMAT, true).isValid()) {
+    return null;
+  }
+  const lines = parseLinesParam(params.get("lines"));
+  if (lines.length === 0) {
+    return null;
+  }
+  const ministryId = params.get("ministryId") || undefined;
+  return { date, ministryId, lines };
+};
+
+export const toBookingCartDraftParams = (draft: BookingCartDraft): URLSearchParams => {
+  const params = new URLSearchParams();
+  params.set("date", draft.date);
+  params.set(
+    "lines",
+    [...draft.lines]
+      .sort((left, right) => left.sequence - right.sequence)
+      .slice(0, MAX_BOOKING_LINES)
+      .map(encodeLine)
+      .join(LINE_SEP)
+  );
+  if (draft.ministryId) {
+    params.set("ministryId", draft.ministryId);
+  }
+  return params;
+};
+
+export const cartStateToDraft = (
+  date: string,
+  ministryId: string | undefined,
+  state: TimetableCartState
+): BookingCartDraft | null => {
+  if (state.lines.length === 0) {
+    return null;
+  }
+  return {
+    date,
+    ministryId,
+    lines: state.lines.map((line) => ({
+      facilityId: line.facilityId,
+      start: line.start,
+      end: line.end,
+      sequence: line.sequence,
+    })),
+  };
+};
+
+export const draftToCartState = (draft: BookingCartDraft, whenSeed: WhenSeedRange | null): TimetableCartState => {
+  return {
+    lines: draft.lines.map((line) => ({
+      facilityId: line.facilityId,
+      start: line.start,
+      end: line.end,
+      sequence: line.sequence,
+    })),
+    pinned: null,
+    whenSeed,
+  };
+};
+
+export const bookingLinesFromDraft = (draft: BookingCartDraft): BookingLine[] => {
+  return draft.lines.map((line) => ({
+    facilityId: line.facilityId,
+    start: line.start,
+    end: line.end,
+    sequence: line.sequence,
+  }));
+};

--- a/src/utils/timetableRules.test.ts
+++ b/src/utils/timetableRules.test.ts
@@ -1,25 +1,36 @@
 import { describe, expect, it } from "vitest";
 import {
-  MAX_SELECTED_ROOMS,
-  bookRoom,
+  addCartLine,
+  blockActionForInterval,
+  canAddCartLine,
   canConfirmBookingTime,
-  canReviewBooking,
-  confirmBookingTimePrefill,
+  canReviewCart,
   capacityBandFor,
-  clearUnconfirmedSelection,
+  cartPointerAction,
+  confirmBookingTimePrefill,
+  confirmBookingTimePrefillForCart,
   displayBlocks,
+  displayBlocksForCart,
+  emptyCartState,
   emptyTimeBookInterval,
   emptyTimePointerAction,
+  hasDuplicateLine,
   hasNoMatchingResults,
+  intervalStaysOnSameDay,
   isTimetableInitialLoad,
   isRoomAvailable,
+  isWhenSeedEligible,
   matchesCapacityBand,
-  removeSelectedRoom,
+  MAX_BOOKING_LINES,
+  pinInterval,
+  removeCartLine,
   scrollTargetClock,
+  scrollTargetClockForCart,
+  updateCartLine,
   visibleRooms,
   type BookingInterval,
   type RoomDay,
-  type TimetableSelection,
+  type TimetableCartState,
 } from "./timetableRules";
 
 const gymCells = (overrides: Partial<Record<string, RoomDay["cells"][number]["state"]>> = {}): RoomDay["cells"] => {
@@ -82,6 +93,8 @@ const sanctuary = (): RoomDay => ({
   cells: gymCells(),
 });
 
+const whenSeed = { start: "10:00", end: "11:00" };
+
 describe("emptyTimeBookInterval", () => {
   it("starts at the clicked Slot for Template duration 60", () => {
     expect(emptyTimeBookInterval(gym(), "09:30")).toEqual({ start: "09:30", end: "10:30" });
@@ -133,56 +146,178 @@ describe("isRoomAvailable", () => {
   });
 });
 
-describe("bookRoom", () => {
-  const empty: TimetableSelection = { roomIds: [], interval: null };
-
-  it("seeds Time from the clicked Slot when Time is empty", () => {
-    const next = bookRoom(empty, gym(), "09:30", "single");
-    expect(next.interval).toEqual({ start: "09:30", end: "10:30" });
-    expect(next.roomIds).toEqual(["gym-id"]);
+describe("isWhenSeedEligible", () => {
+  it("is false when When seed is absent", () => {
+    expect(isWhenSeedEligible(gym(), null)).toBe(false);
   });
 
-  it("keeps Time and replaces the room in Single", () => {
-    const selected: TimetableSelection = { roomIds: ["chapel-id"], interval: { start: "10:00", end: "11:00" } };
-    const next = bookRoom(selected, gym(), "10:00", "single");
-    expect(next.interval).toEqual({ start: "10:00", end: "11:00" });
-    expect(next.roomIds).toEqual(["gym-id"]);
+  it("is true when the room can cover the When seed interval", () => {
+    expect(isWhenSeedEligible(gym(), whenSeed)).toBe(true);
+    expect(isWhenSeedEligible(chapel(), whenSeed)).toBe(true);
   });
 
-  it("adds a second room in Multiple without changing Time", () => {
-    const selected: TimetableSelection = { roomIds: ["chapel-id"], interval: { start: "10:00", end: "11:00" } };
-    const next = bookRoom(selected, gym(), "10:00", "multiple");
-    expect(next.interval).toEqual({ start: "10:00", end: "11:00" });
-    expect(next.roomIds).toEqual(["chapel-id", "gym-id"]);
+  it("is false when the room cannot cover the When seed interval", () => {
+    expect(isWhenSeedEligible(chapel(), { start: "10:00", end: "13:00" })).toBe(false);
+  });
+});
+
+describe("pinInterval", () => {
+  it("sets Pinned interval for one room only and keeps When seed on the cart state", () => {
+    const state = emptyCartState(whenSeed);
+    const next = pinInterval(state, gym(), "09:30");
+    expect(next.pinned).toEqual({ facilityId: "gym-id", start: "09:30", end: "10:30" });
+    expect(next.whenSeed).toEqual(whenSeed);
+    expect(next.lines).toEqual([]);
   });
 
-  it("caps Multiple at three rooms", () => {
-    const selected: TimetableSelection = {
-      roomIds: ["a", "b", "c"],
-      interval: { start: "10:00", end: "11:00" },
+  it("does not change state when the clicked Slot cannot book", () => {
+    const state = emptyCartState(whenSeed);
+    const occupied = gym({ cells: gymCells({ "09:30": "unavailable" }) });
+    expect(pinInterval(state, occupied, "09:30")).toBe(state);
+  });
+
+  it("replaces the previous pin when another room is clicked", () => {
+    let state = pinInterval(emptyCartState(whenSeed), gym(), "09:30");
+    state = pinInterval(state, chapel(), "10:00");
+    expect(state.pinned).toEqual({ facilityId: "chapel-id", start: "10:00", end: "11:00" });
+    expect(state.whenSeed).toEqual(whenSeed);
+  });
+});
+
+describe("cart mutations", () => {
+  const baseLine = { facilityId: "gym-id", start: "10:00", end: "11:00" };
+
+  it("adds a confirmed Booking line with sequence", () => {
+    const next = addCartLine(emptyCartState(), baseLine);
+    expect(next?.lines).toEqual([{ ...baseLine, sequence: 1 }]);
+  });
+
+  it("rejects duplicate lines keyed by facilityId, start, and end", () => {
+    const state: TimetableCartState = {
+      lines: [{ ...baseLine, sequence: 1 }],
+      pinned: null,
+      whenSeed: null,
     };
-    const next = bookRoom(selected, gym(), "10:00", "multiple");
-    expect(next.roomIds).toHaveLength(MAX_SELECTED_ROOMS);
+    expect(canAddCartLine(state, baseLine)).toBe(false);
+    expect(addCartLine(state, baseLine)).toBeNull();
   });
 
-  it("replaces the shared interval when ADD starts a different span", () => {
-    const selected: TimetableSelection = { roomIds: ["chapel-id"], interval: { start: "10:00", end: "11:00" } };
-    const next = bookRoom(selected, gym(), "14:00", "multiple");
-    expect(next.interval).toEqual({ start: "14:00", end: "15:00" });
-    expect(next.roomIds).toEqual(["gym-id"]);
+  it("allows the same room at a different time as a separate line", () => {
+    const state: TimetableCartState = {
+      lines: [{ ...baseLine, sequence: 1 }],
+      pinned: null,
+      whenSeed: null,
+    };
+    const afternoon = { facilityId: "gym-id", start: "14:00", end: "15:00" };
+    expect(canAddCartLine(state, afternoon)).toBe(true);
+    expect(addCartLine(state, afternoon)?.lines).toHaveLength(2);
+  });
+
+  it("caps the cart at three lines", () => {
+    let state = emptyCartState();
+    state = addCartLine(state, baseLine)!;
+    state = addCartLine(state, { facilityId: "chapel-id", start: "10:00", end: "11:00" })!;
+    state = addCartLine(state, { facilityId: "sanctuary-id", start: "10:00", end: "11:00" })!;
+    expect(state.lines).toHaveLength(MAX_BOOKING_LINES);
+    expect(canAddCartLine(state, { facilityId: "gym-id", start: "15:00", end: "16:00" })).toBe(false);
+  });
+
+  it("rejects lines that cross midnight", () => {
+    expect(intervalStaysOnSameDay({ start: "23:00", end: "01:00" })).toBe(false);
+    expect(canAddCartLine(emptyCartState(), { facilityId: "gym-id", start: "23:00", end: "01:00" })).toBe(false);
+  });
+
+  it("updates one line without creating a duplicate", () => {
+    const state: TimetableCartState = {
+      lines: [
+        { facilityId: "gym-id", start: "10:00", end: "11:00", sequence: 1 },
+        { facilityId: "chapel-id", start: "10:00", end: "11:00", sequence: 2 },
+      ],
+      pinned: null,
+      whenSeed: null,
+    };
+    const updated = updateCartLine(state, 1, { facilityId: "gym-id", start: "10:00", end: "12:00" });
+    expect(updated?.lines.find((line) => line.sequence === 1)).toEqual({
+      facilityId: "gym-id",
+      start: "10:00",
+      end: "12:00",
+      sequence: 1,
+    });
+    expect(hasDuplicateLine(updated!.lines, { facilityId: "chapel-id", start: "10:00", end: "11:00" })).toBe(true);
+  });
+
+  it("removes a line by sequence", () => {
+    const state: TimetableCartState = {
+      lines: [{ ...baseLine, sequence: 1 }],
+      pinned: null,
+      whenSeed: null,
+    };
+    expect(removeCartLine(state, 1).lines).toEqual([]);
+  });
+});
+
+describe("blockActionForInterval", () => {
+  it("shows ADD until the line is confirmed in the cart", () => {
+    const interval = { start: "10:00", end: "11:00" };
+    expect(blockActionForInterval([], "gym-id", interval)).toBe("add");
+    expect(blockActionForInterval([{ facilityId: "gym-id", ...interval, sequence: 1 }], "gym-id", interval)).toBe(
+      "checkmark"
+    );
+  });
+
+  it("returns ADD again after the matching line is removed", () => {
+    const interval = { start: "10:00", end: "11:00" };
+    const without = removeCartLine(
+      {
+        lines: [{ facilityId: "gym-id", ...interval, sequence: 1 }],
+        pinned: null,
+        whenSeed: null,
+      },
+      1
+    );
+    expect(blockActionForInterval(without.lines, "gym-id", interval)).toBe("add");
+  });
+});
+
+describe("canReviewCart", () => {
+  it("is disabled until at least one Booking line exists", () => {
+    expect(canReviewCart(emptyCartState())).toBe(false);
+    expect(
+      canReviewCart({
+        lines: [{ facilityId: "gym-id", start: "10:00", end: "11:00", sequence: 1 }],
+        pinned: null,
+        whenSeed: null,
+      })
+    ).toBe(true);
   });
 });
 
 describe("confirmBookingTimePrefill", () => {
-  it("prefills the existing Booking interval pair", () => {
+  it("prefills the existing interval pair", () => {
     expect(confirmBookingTimePrefill(gym(), "09:30", { start: "10:00", end: "11:30" })).toEqual({
       start: "10:00",
       end: "11:30",
     });
   });
 
-  it("prefills Slot start plus Template duration when Time is empty", () => {
+  it("prefills Slot start plus Template duration when no interval is provided", () => {
     expect(confirmBookingTimePrefill(gym(), "09:30", null)).toEqual({ start: "09:30", end: "10:30" });
+  });
+});
+
+describe("confirmBookingTimePrefillForCart", () => {
+  it("prefills from the pinned interval for that room", () => {
+    const state = pinInterval(emptyCartState(), gym(), "09:30");
+    expect(confirmBookingTimePrefillForCart(gym(), state, "09:30")).toEqual({ start: "09:30", end: "10:30" });
+  });
+
+  it("prefills from the line being edited", () => {
+    const state: TimetableCartState = {
+      lines: [{ facilityId: "gym-id", start: "10:00", end: "11:30", sequence: 1 }],
+      pinned: null,
+      whenSeed: null,
+    };
+    expect(confirmBookingTimePrefillForCart(gym(), state, "09:30", 1)).toEqual({ start: "10:00", end: "11:30" });
   });
 });
 
@@ -207,13 +342,6 @@ describe("canConfirmBookingTime", () => {
   });
 });
 
-describe("canReviewBooking", () => {
-  it("is disabled until at least one room is selected", () => {
-    expect(canReviewBooking({ roomIds: [], interval: { start: "10:00", end: "11:00" } })).toBe(false);
-    expect(canReviewBooking({ roomIds: ["gym-id"], interval: { start: "10:00", end: "11:00" } })).toBe(true);
-  });
-});
-
 describe("capacityBandFor", () => {
   it("counts capacity 10 as 1-10", () => {
     expect(capacityBandFor(10)).toBe("1-10");
@@ -226,36 +354,32 @@ describe("visibleRooms", () => {
   const rooms = [gym(), chapel(), sanctuary()];
   const interval: BookingInterval = { start: "10:00", end: "11:00" };
 
-  it("defaults Available rooms to rooms that can be BOOK'd", () => {
+  it("defaults Available rooms to rooms that can be booked for the interval", () => {
     const occupiedGym = gym({ cells: gymCells({ "10:00": "unavailable", "10:30": "unavailable" }) });
-    const list = visibleRooms([occupiedGym, chapel()], "available", interval, null, undefined);
+    const list = visibleRooms([occupiedGym, chapel()], "available", interval, null);
     expect(list.map((room) => room.id)).toEqual(["chapel-id"]);
   });
 
   it("keeps All rooms columns with no Available block", () => {
     const occupiedGym = gym({ cells: gymCells({ "10:00": "unavailable", "10:30": "unavailable" }) });
-    const list = visibleRooms([occupiedGym, chapel()], "all", interval, null, undefined);
+    const list = visibleRooms([occupiedGym, chapel()], "all", interval, null);
     expect(list.map((room) => room.id)).toEqual(["gym-id", "chapel-id"]);
   });
 
-  it("filters by Room shortcut", () => {
-    expect(visibleRooms(rooms, "all", interval, null, "gym").map((room) => room.code)).toEqual(["gym"]);
-  });
-
   it("filters by capacity band", () => {
-    expect(visibleRooms(rooms, "all", interval, "1-10", undefined).map((room) => room.code)).toEqual(["chapel"]);
+    expect(visibleRooms(rooms, "all", interval, "1-10").map((room) => room.code)).toEqual(["chapel"]);
   });
 });
 
 describe("hasNoMatchingResults", () => {
-  it("is true on Available rooms when nothing can be BOOK'd", () => {
+  it("is true on Available rooms when nothing can be booked", () => {
     const occupied = gym({ cells: gymCells({ "10:00": "unavailable", "10:30": "unavailable" }) });
-    expect(hasNoMatchingResults([occupied], "available", { start: "10:00", end: "11:00" }, null, undefined)).toBe(true);
-    expect(hasNoMatchingResults([occupied], "all", { start: "10:00", end: "11:00" }, null, undefined)).toBe(false);
+    expect(hasNoMatchingResults([occupied], "available", { start: "10:00", end: "11:00" }, null)).toBe(true);
+    expect(hasNoMatchingResults([occupied], "all", { start: "10:00", end: "11:00" }, null)).toBe(false);
   });
 
   it("is true when availability has not loaded yet", () => {
-    expect(hasNoMatchingResults([], "available", null, null, undefined)).toBe(true);
+    expect(hasNoMatchingResults([], "available", null, null)).toBe(true);
   });
 });
 
@@ -264,23 +388,6 @@ describe("isTimetableInitialLoad", () => {
     expect(isTimetableInitialLoad(true, 0)).toBe(true);
     expect(isTimetableInitialLoad(true, 2)).toBe(false);
     expect(isTimetableInitialLoad(false, 0)).toBe(false);
-  });
-});
-
-describe("clearUnconfirmedSelection", () => {
-  it("clears rooms selected but not yet confirmed", () => {
-    const selected: TimetableSelection = { roomIds: ["gym-id"], interval: { start: "10:00", end: "11:00" } };
-    expect(clearUnconfirmedSelection(selected)).toEqual({ roomIds: [], interval: selected.interval });
-  });
-});
-
-describe("removeSelectedRoom", () => {
-  it("drops that room and keeps the rest", () => {
-    const selected: TimetableSelection = {
-      roomIds: ["gym-id", "chapel-id"],
-      interval: { start: "10:00", end: "11:00" },
-    };
-    expect(removeSelectedRoom(selected, "gym-id").roomIds).toEqual(["chapel-id"]);
   });
 });
 
@@ -298,41 +405,35 @@ describe("displayBlocks", () => {
     expect(displayBlocks(chapel(), null, hover).some((block) => block.state === "available")).toBe(false);
   });
 
-  it("does not preview Available that would cross midnight", () => {
-    const late = gym({
-      templates: [{ start: "22:00", end: "24:00", slotDurationMinutes: 60 }],
-      cells: gymCells({
-        "22:00": "available",
-        "22:30": "available",
-        "23:00": "available",
-        "23:30": "available",
-      }),
-    });
-    const blocks = displayBlocks(late, null, { roomId: "gym-id", cellStart: "23:30" });
-    expect(blocks.some((block) => block.state === "available")).toBe(false);
-  });
-
   it("paints Available only on the Booking interval", () => {
     const blocks = displayBlocks(gym(), { start: "10:00", end: "11:30" });
     expect(blocks.filter((block) => block.state === "available")).toEqual([
       { start: "10:00", end: "11:30", state: "available" },
     ]);
   });
+});
 
-  it("paints committed Available without hover on rooms that cover the interval", () => {
-    const interval = { start: "10:00", end: "11:00" };
-    expect(displayBlocks(gym(), interval).filter((block) => block.state === "available")).toEqual([
+describe("displayBlocksForCart", () => {
+  it("paints When seed highlight on eligible rooms without adding cart lines", () => {
+    const state = emptyCartState(whenSeed);
+    expect(displayBlocksForCart(gym(), state).filter((block) => block.state === "available")).toEqual([
       { start: "10:00", end: "11:00", state: "available" },
     ]);
-    expect(displayBlocks(chapel(), interval).filter((block) => block.state === "available")).toEqual([
-      { start: "10:00", end: "11:00", state: "available" },
-    ]);
+    expect(
+      displayBlocksForCart(chapel(), { ...state, whenSeed: { start: "10:00", end: "13:00" } }).some(
+        (block) => block.state === "available"
+      )
+    ).toBe(false);
   });
 
-  it("keeps Unavailable blocks when Time is set", () => {
-    const occupied = gym({ cells: gymCells({ "13:00": "unavailable", "13:30": "unavailable" }) });
-    const blocks = displayBlocks(occupied, { start: "10:00", end: "11:00" });
-    expect(blocks).toContainEqual({ start: "13:00", end: "14:00", state: "unavailable" });
+  it("keeps When seed on other rooms when one room is pinned", () => {
+    const state = pinInterval(emptyCartState(whenSeed), gym(), "09:30");
+    expect(displayBlocksForCart(chapel(), state).filter((block) => block.state === "available")).toEqual([
+      { start: "10:00", end: "11:00", state: "available" },
+    ]);
+    expect(displayBlocksForCart(gym(), state).filter((block) => block.state === "available")).toEqual([
+      { start: "09:30", end: "10:30", state: "available" },
+    ]);
   });
 });
 
@@ -362,12 +463,17 @@ describe("scrollTargetClock", () => {
     });
     expect(scrollTargetClock([lateGym, earlyChapel], null)).toBe("07:30");
   });
+});
 
-  it("falls back to 00:00 when every Slot is Closed", () => {
-    const closed = gym({
-      cells: gym().cells.map((cell) => ({ ...cell, state: "closed" as const })),
-    });
-    expect(scrollTargetClock([closed], null)).toBe("00:00");
+describe("scrollTargetClockForCart", () => {
+  it("prefers When seed start over pinned and earliest open Slot", () => {
+    const pinned = { facilityId: "gym-id", start: "09:30", end: "10:30" };
+    expect(scrollTargetClockForCart([gym(), chapel()], whenSeed, pinned)).toBe("10:00");
+  });
+
+  it("uses pinned start when When seed is absent", () => {
+    const pinned = { facilityId: "gym-id", start: "09:30", end: "10:30" };
+    expect(scrollTargetClockForCart([gym(), chapel()], null, pinned)).toBe("09:30");
   });
 });
 
@@ -380,12 +486,16 @@ describe("emptyTimePointerAction", () => {
     const gymSlot = { roomId: "gym-id", cellStart: "09:30" };
     expect(emptyTimePointerAction(null, "touch", null, gymSlot)).toBe("preview");
     expect(emptyTimePointerAction(null, "touch", gymSlot, gymSlot)).toBe("commit");
-    expect(emptyTimePointerAction(null, "touch", gymSlot, { roomId: "gym-id", cellStart: "10:00" })).toBe("preview");
   });
+});
 
-  it("commits when Time is already set", () => {
+describe("cartPointerAction", () => {
+  it("commits when a room is already pinned", () => {
     expect(
-      emptyTimePointerAction({ start: "10:00", end: "11:00" }, "touch", null, { roomId: "gym-id", cellStart: "10:00" })
+      cartPointerAction({ facilityId: "gym-id", start: "09:30", end: "10:30" }, "touch", null, {
+        roomId: "gym-id",
+        cellStart: "10:00",
+      })
     ).toBe("commit");
   });
 });

--- a/src/utils/timetableRules.ts
+++ b/src/utils/timetableRules.ts
@@ -1,5 +1,5 @@
 export const SLOT_MINUTES = 30;
-export const MAX_SELECTED_ROOMS = 3;
+export const MAX_BOOKING_LINES = 3;
 
 export type CellState = "available" | "unavailable" | "closed" | "override";
 
@@ -7,9 +7,7 @@ export type TimetableView = "available" | "all";
 
 export type CapacityBand = "1-10" | "10-25" | "25-50" | "50+";
 
-export type RoomsSpace = "single" | "multiple";
-
-export type RoomShortcutCode = "gym" | "sanctuary-hall";
+export type BlockAction = "add" | "checkmark";
 
 export interface TimeRange {
   start: string;
@@ -34,15 +32,30 @@ export interface RoomDay {
   cells: TimeCell[];
 }
 
-export interface BookingInterval {
-  start: string;
-  end: string;
+export type BookingInterval = TimeRange;
+
+export type WhenSeedRange = TimeRange;
+
+export interface BookingLine extends TimeRange {
+  facilityId: string;
+  sequence: number;
 }
 
-export interface TimetableSelection {
-  roomIds: string[];
-  interval: BookingInterval | null;
+export interface PinnedInterval extends TimeRange {
+  facilityId: string;
 }
+
+export interface TimetableCartState {
+  lines: BookingLine[];
+  pinned: PinnedInterval | null;
+  whenSeed: WhenSeedRange | null;
+}
+
+export const emptyCartState = (whenSeed: WhenSeedRange | null = null): TimetableCartState => ({
+  lines: [],
+  pinned: null,
+  whenSeed,
+});
 
 export const clockToMinutes = (clock: string): number => {
   if (clock === "24:00") {
@@ -61,8 +74,14 @@ export const minutesToClock = (totalMinutes: number): string => {
   return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 };
 
-export const intervalLengthMinutes = (interval: BookingInterval): number => {
+export const intervalLengthMinutes = (interval: TimeRange): number => {
   return clockToMinutes(interval.end) - clockToMinutes(interval.start);
+};
+
+export const intervalStaysOnSameDay = (interval: TimeRange): boolean => {
+  const startMinutes = clockToMinutes(interval.start);
+  const endMinutes = clockToMinutes(interval.end);
+  return startMinutes >= 0 && endMinutes > startMinutes && endMinutes <= 24 * 60;
 };
 
 export const durationForRoom = (room: RoomDay, atStart?: string): number => {
@@ -121,7 +140,7 @@ export const isRoomAvailable = (room: RoomDay, interval: BookingInterval | null)
   return true;
 };
 
-const isCellInInterval = (cellStart: string, interval: BookingInterval): boolean => {
+export const isCellInInterval = (cellStart: string, interval: TimeRange): boolean => {
   const startMinutes = clockToMinutes(interval.start);
   const endMinutes = clockToMinutes(interval.end);
   const cellMinutes = clockToMinutes(cellStart);
@@ -135,6 +154,152 @@ export const isBookableCell = (room: RoomDay, cellStart: string, interval: Booki
   return emptyTimeBookInterval(room, cellStart) != null;
 };
 
+export const isBookableCellForCart = (room: RoomDay, cellStart: string, pinned: PinnedInterval | null): boolean => {
+  if (pinned?.facilityId === room.id && isCellInInterval(cellStart, pinned) && isRoomAvailable(room, pinned)) {
+    return true;
+  }
+  return emptyTimeBookInterval(room, cellStart) != null;
+};
+
+export const isWhenSeedEligible = (room: RoomDay, whenSeed: WhenSeedRange | null): boolean => {
+  if (!whenSeed) {
+    return false;
+  }
+  return isRoomAvailable(room, whenSeed);
+};
+
+export const lineIdentityKey = (line: Pick<BookingLine, "facilityId" | "start" | "end">): string => {
+  return `${line.facilityId}\0${line.start}\0${line.end}`;
+};
+
+export const intervalsMatch = (left: TimeRange, right: TimeRange): boolean => {
+  return left.start === right.start && left.end === right.end;
+};
+
+export const hasDuplicateLine = (
+  lines: BookingLine[],
+  candidate: Pick<BookingLine, "facilityId" | "start" | "end">
+): boolean => {
+  const key = lineIdentityKey(candidate);
+  return lines.some((line) => lineIdentityKey(line) === key);
+};
+
+export const nextLineSequence = (lines: BookingLine[]): number => {
+  if (lines.length === 0) {
+    return 1;
+  }
+  return Math.max(...lines.map((line) => line.sequence)) + 1;
+};
+
+export const canAddCartLine = (
+  state: TimetableCartState,
+  line: Pick<BookingLine, "facilityId" | "start" | "end">
+): boolean => {
+  if (state.lines.length >= MAX_BOOKING_LINES) {
+    return false;
+  }
+  if (hasDuplicateLine(state.lines, line)) {
+    return false;
+  }
+  return intervalStaysOnSameDay(line);
+};
+
+export const pinInterval = (state: TimetableCartState, room: RoomDay, cellStart: string): TimetableCartState => {
+  const interval = emptyTimeBookInterval(room, cellStart);
+  if (!interval) {
+    return state;
+  }
+  return {
+    ...state,
+    pinned: {
+      facilityId: room.id,
+      start: interval.start,
+      end: interval.end,
+    },
+  };
+};
+
+export const pinnedIntervalForRoom = (state: TimetableCartState, facilityId: string): BookingInterval | null => {
+  if (state.pinned?.facilityId !== facilityId) {
+    return null;
+  }
+  return { start: state.pinned.start, end: state.pinned.end };
+};
+
+export const addCartLine = (
+  state: TimetableCartState,
+  line: Pick<BookingLine, "facilityId" | "start" | "end">
+): TimetableCartState | null => {
+  if (!canAddCartLine(state, line)) {
+    return null;
+  }
+  const nextLine: BookingLine = {
+    facilityId: line.facilityId,
+    start: line.start,
+    end: line.end,
+    sequence: nextLineSequence(state.lines),
+  };
+  return {
+    ...state,
+    lines: [...state.lines, nextLine].sort((left, right) => left.sequence - right.sequence),
+    pinned: state.pinned?.facilityId === line.facilityId ? null : state.pinned,
+  };
+};
+
+export const updateCartLine = (
+  state: TimetableCartState,
+  sequence: number,
+  line: Pick<BookingLine, "facilityId" | "start" | "end">
+): TimetableCartState | null => {
+  const existing = state.lines.find((item) => item.sequence === sequence);
+  if (!existing) {
+    return null;
+  }
+  const without = state.lines.filter((item) => item.sequence !== sequence);
+  if (hasDuplicateLine(without, line)) {
+    return null;
+  }
+  if (!intervalStaysOnSameDay(line)) {
+    return null;
+  }
+  const updated: BookingLine = {
+    facilityId: line.facilityId,
+    start: line.start,
+    end: line.end,
+    sequence,
+  };
+  return {
+    ...state,
+    lines: [...without, updated].sort((left, right) => left.sequence - right.sequence),
+  };
+};
+
+export const removeCartLine = (state: TimetableCartState, sequence: number): TimetableCartState => {
+  return {
+    ...state,
+    lines: state.lines.filter((line) => line.sequence !== sequence),
+  };
+};
+
+export const findCartLineByIdentity = (
+  lines: BookingLine[],
+  facilityId: string,
+  interval: TimeRange
+): BookingLine | undefined => {
+  return lines.find((line) => line.facilityId === facilityId && intervalsMatch(line, interval));
+};
+
+export const blockActionForInterval = (lines: BookingLine[], facilityId: string, interval: TimeRange): BlockAction => {
+  if (findCartLineByIdentity(lines, facilityId, interval)) {
+    return "checkmark";
+  }
+  return "add";
+};
+
+export const canReviewCart = (state: TimetableCartState): boolean => {
+  return state.lines.length > 0;
+};
+
 export const confirmBookingTimePrefill = (
   room: RoomDay,
   cellStart: string,
@@ -142,6 +307,25 @@ export const confirmBookingTimePrefill = (
 ): BookingInterval | null => {
   if (existing) {
     return existing;
+  }
+  return emptyTimeBookInterval(room, cellStart);
+};
+
+export const confirmBookingTimePrefillForCart = (
+  room: RoomDay,
+  state: TimetableCartState,
+  cellStart: string,
+  editingSequence?: number
+): BookingInterval | null => {
+  if (editingSequence != null) {
+    const editing = state.lines.find((line) => line.sequence === editingSequence);
+    if (editing) {
+      return { start: editing.start, end: editing.end };
+    }
+  }
+  const pinned = pinnedIntervalForRoom(state, room.id);
+  if (pinned) {
+    return pinned;
   }
   return emptyTimeBookInterval(room, cellStart);
 };
@@ -154,37 +338,6 @@ export const canConfirmBookingTime = (room: RoomDay, interval: BookingInterval |
     return false;
   }
   return isRoomAvailable(room, interval);
-};
-
-export const bookRoom = (
-  selection: TimetableSelection,
-  room: RoomDay,
-  cellStart: string,
-  space: RoomsSpace
-): TimetableSelection => {
-  const current = selection.interval;
-  if (current && isCellInInterval(cellStart, current) && isRoomAvailable(room, current)) {
-    if (space === "single") {
-      return { roomIds: [room.id], interval: current };
-    }
-    if (selection.roomIds.includes(room.id)) {
-      return selection;
-    }
-    if (selection.roomIds.length >= MAX_SELECTED_ROOMS) {
-      return selection;
-    }
-    return { roomIds: [...selection.roomIds, room.id], interval: current };
-  }
-
-  const nextInterval = emptyTimeBookInterval(room, cellStart);
-  if (!nextInterval) {
-    return selection;
-  }
-  return { roomIds: [room.id], interval: nextInterval };
-};
-
-export const canReviewBooking = (selection: TimetableSelection): boolean => {
-  return selection.roomIds.length > 0 && selection.interval != null;
 };
 
 export const capacityBandFor = (capacity: number): CapacityBand | null => {
@@ -210,21 +363,13 @@ export const matchesCapacityBand = (room: RoomDay, band: CapacityBand | null): b
   return capacityBandFor(room.capacity) === band;
 };
 
-export const matchesRoomShortcut = (room: RoomDay, shortcut: RoomShortcutCode | undefined): boolean => {
-  if (!shortcut) {
-    return true;
-  }
-  return room.code === shortcut;
-};
-
 export const visibleRooms = (
   rooms: RoomDay[],
   view: TimetableView,
   interval: BookingInterval | null,
-  band: CapacityBand | null,
-  shortcut: RoomShortcutCode | undefined
+  band: CapacityBand | null
 ): RoomDay[] => {
-  const filtered = rooms.filter((room) => matchesCapacityBand(room, band) && matchesRoomShortcut(room, shortcut));
+  const filtered = rooms.filter((room) => matchesCapacityBand(room, band));
   if (view === "all") {
     return filtered;
   }
@@ -235,18 +380,13 @@ export const hasNoMatchingResults = (
   rooms: RoomDay[],
   view: TimetableView,
   interval: BookingInterval | null,
-  band: CapacityBand | null,
-  shortcut: RoomShortcutCode | undefined
+  band: CapacityBand | null
 ): boolean => {
-  return view === "available" && visibleRooms(rooms, view, interval, band, shortcut).length === 0;
+  return view === "available" && visibleRooms(rooms, view, interval, band).length === 0;
 };
 
 export const isTimetableInitialLoad = (loading: boolean, roomCount: number): boolean => {
   return loading && roomCount === 0;
-};
-
-export const clearUnconfirmedSelection = (selection: TimetableSelection): TimetableSelection => {
-  return { roomIds: [], interval: selection.interval };
 };
 
 export const scrollTargetClock = (rooms: RoomDay[], interval: BookingInterval | null): string => {
@@ -267,8 +407,18 @@ export const scrollTargetClock = (rooms: RoomDay[], interval: BookingInterval | 
   return minutesToClock(earliest);
 };
 
-export const removeSelectedRoom = (selection: TimetableSelection, roomId: string): TimetableSelection => {
-  return { ...selection, roomIds: selection.roomIds.filter((id) => id !== roomId) };
+export const scrollTargetClockForCart = (
+  rooms: RoomDay[],
+  whenSeed: WhenSeedRange | null,
+  pinned: PinnedInterval | null
+): string => {
+  if (whenSeed) {
+    return whenSeed.start;
+  }
+  if (pinned) {
+    return pinned.start;
+  }
+  return scrollTargetClock(rooms, null);
 };
 
 export interface HoverPreview {
@@ -285,6 +435,21 @@ export const emptyTimePointerAction = (
   target: HoverPreview
 ): "preview" | "commit" => {
   if (interval != null || pointerKind === "mouse") {
+    return "commit";
+  }
+  if (hover?.roomId === target.roomId && hover.cellStart === target.cellStart) {
+    return "commit";
+  }
+  return "preview";
+};
+
+export const cartPointerAction = (
+  pinned: PinnedInterval | null,
+  pointerKind: PointerKind,
+  hover: HoverPreview | null,
+  target: HoverPreview
+): "preview" | "commit" => {
+  if (pinned != null || pointerKind === "mouse") {
     return "commit";
   }
   if (hover?.roomId === target.roomId && hover.cellStart === target.cellStart) {
@@ -328,4 +493,31 @@ export const displayBlocks = (
     }
   }
   return occupied;
+};
+
+export const displayBlocksForCart = (
+  room: RoomDay,
+  state: TimetableCartState,
+  hover: HoverPreview | null = null
+): CellBlock[] => {
+  const occupied = contiguousBlocks(room).filter(
+    (block) => block.state === "unavailable" || block.state === "override"
+  );
+  const overlays: CellBlock[] = [];
+
+  if (isWhenSeedEligible(room, state.whenSeed) && state.whenSeed && state.pinned?.facilityId !== room.id) {
+    overlays.push({ start: state.whenSeed.start, end: state.whenSeed.end, state: "available" });
+  }
+
+  const pinned = pinnedIntervalForRoom(state, room.id);
+  if (pinned && isRoomAvailable(room, pinned)) {
+    overlays.push({ start: pinned.start, end: pinned.end, state: "available" });
+  } else if (!pinned && hover?.roomId === room.id) {
+    const preview = emptyTimeBookInterval(room, hover.cellStart);
+    if (preview) {
+      overlays.push({ start: preview.start, end: preview.end, state: "available" });
+    }
+  }
+
+  return [...occupied, ...overlays];
 };

--- a/src/utils/timetableRulesLegacy.test.ts
+++ b/src/utils/timetableRulesLegacy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { MAX_BOOKING_LINES, type RoomDay } from "./timetableRules";
+import { bookRoom, canReviewBooking, type TimetableSelection } from "./timetableRulesLegacy";
+
+const gymCells = (): RoomDay["cells"] => {
+  const cells: RoomDay["cells"] = [];
+  for (let minutes = 9 * 60; minutes < 17 * 60; minutes += 30) {
+    const start = `${String(Math.floor(minutes / 60)).padStart(2, "0")}:${String(minutes % 60).padStart(2, "0")}`;
+    const endMinutes = minutes + 30;
+    const end = `${String(Math.floor(endMinutes / 60)).padStart(2, "0")}:${String(endMinutes % 60).padStart(2, "0")}`;
+    cells.push({ start, end, state: "available" });
+  }
+  return cells;
+};
+
+const gym = (): RoomDay => ({
+  id: "gym-id",
+  code: "gym",
+  name: "Gym",
+  capacity: 200,
+  photoUrls: [],
+  templates: [{ start: "09:00", end: "17:00", slotDurationMinutes: 60 }],
+  cells: gymCells(),
+});
+
+describe("bookRoom legacy selection", () => {
+  const empty: TimetableSelection = { roomIds: [], interval: null };
+
+  it("seeds Time from the clicked Slot when Time is empty", () => {
+    const next = bookRoom(empty, gym(), "09:30", "single");
+    expect(next.interval).toEqual({ start: "09:30", end: "10:30" });
+    expect(next.roomIds).toEqual(["gym-id"]);
+  });
+
+  it("caps Multiple at three rooms", () => {
+    const selected: TimetableSelection = {
+      roomIds: ["a", "b", "c"],
+      interval: { start: "10:00", end: "11:00" },
+    };
+    const next = bookRoom(selected, gym(), "10:00", "multiple");
+    expect(next.roomIds).toHaveLength(MAX_BOOKING_LINES);
+  });
+});
+
+describe("canReviewBooking legacy selection", () => {
+  it("requires at least one room and a shared interval", () => {
+    expect(canReviewBooking({ roomIds: [], interval: { start: "10:00", end: "11:00" } })).toBe(false);
+    expect(canReviewBooking({ roomIds: ["gym-id"], interval: { start: "10:00", end: "11:00" } })).toBe(true);
+  });
+});

--- a/src/utils/timetableRulesLegacy.ts
+++ b/src/utils/timetableRulesLegacy.ts
@@ -1,0 +1,96 @@
+import {
+  MAX_BOOKING_LINES,
+  emptyTimeBookInterval,
+  isCellInInterval,
+  isRoomAvailable,
+  matchesCapacityBand,
+  type BookingInterval,
+  type CapacityBand,
+  type RoomDay,
+  type TimetableView,
+} from "./timetableRules";
+
+/** @deprecated Retired with Timetable cart; kept for legacy Timetable UI until #72. */
+export type RoomsSpace = "single" | "multiple";
+
+/** @deprecated Retired room shortcut filter; kept for legacy Timetable UI until #72. */
+export type RoomShortcutCode = "gym" | "sanctuary-hall";
+
+/** @deprecated Shared Booking interval selection; use TimetableCartState instead. */
+export interface TimetableSelection {
+  roomIds: string[];
+  interval: BookingInterval | null;
+}
+
+/** @deprecated Use MAX_BOOKING_LINES from timetableRules. */
+export const MAX_SELECTED_ROOMS = MAX_BOOKING_LINES;
+
+export const matchesRoomShortcut = (room: RoomDay, shortcut: RoomShortcutCode | undefined): boolean => {
+  if (!shortcut) {
+    return true;
+  }
+  return room.code === shortcut;
+};
+
+export const bookRoom = (
+  selection: TimetableSelection,
+  room: RoomDay,
+  cellStart: string,
+  space: RoomsSpace
+): TimetableSelection => {
+  const current = selection.interval;
+  if (current && isCellInInterval(cellStart, current) && isRoomAvailable(room, current)) {
+    if (space === "single") {
+      return { roomIds: [room.id], interval: current };
+    }
+    if (selection.roomIds.includes(room.id)) {
+      return selection;
+    }
+    if (selection.roomIds.length >= MAX_BOOKING_LINES) {
+      return selection;
+    }
+    return { roomIds: [...selection.roomIds, room.id], interval: current };
+  }
+
+  const nextInterval = emptyTimeBookInterval(room, cellStart);
+  if (!nextInterval) {
+    return selection;
+  }
+  return { roomIds: [room.id], interval: nextInterval };
+};
+
+export const canReviewBooking = (selection: TimetableSelection): boolean => {
+  return selection.roomIds.length > 0 && selection.interval != null;
+};
+
+export const clearUnconfirmedSelection = (selection: TimetableSelection): TimetableSelection => {
+  return { roomIds: [], interval: selection.interval };
+};
+
+export const removeSelectedRoom = (selection: TimetableSelection, roomId: string): TimetableSelection => {
+  return { ...selection, roomIds: selection.roomIds.filter((id) => id !== roomId) };
+};
+
+export const visibleRoomsLegacy = (
+  rooms: RoomDay[],
+  view: TimetableView,
+  interval: BookingInterval | null,
+  band: CapacityBand | null,
+  shortcut: RoomShortcutCode | undefined
+): RoomDay[] => {
+  const filtered = rooms.filter((room) => matchesCapacityBand(room, band) && matchesRoomShortcut(room, shortcut));
+  if (view === "all") {
+    return filtered;
+  }
+  return filtered.filter((room) => isRoomAvailable(room, interval));
+};
+
+export const hasNoMatchingResultsLegacy = (
+  rooms: RoomDay[],
+  view: TimetableView,
+  interval: BookingInterval | null,
+  band: CapacityBand | null,
+  shortcut: RoomShortcutCode | undefined
+): boolean => {
+  return view === "available" && visibleRoomsLegacy(rooms, view, interval, band, shortcut).length === 0;
+};


### PR DESCRIPTION
## Summary

Introduce pure-function Timetable cart domain rules and multi-line Booking Details draft encoding for epic #68. Covers pin (single room), When seed highlight eligibility, cart add/edit/remove, duplicate line rejection, max three lines, same-calendar-day constraint, and ADD vs checkmark block state. Legacy shared-interval / Single-Multiple helpers move to `timetableRulesLegacy.ts` so the current Timetable UI keeps compiling until #72 wires the cart panel.

Closes #71

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Cart line identity is `(facilityId, start, end)`; draft URL uses `lines=sequence~facilityId~start~end` (comma-separated).
- `RoomFilterPage` still imports legacy selection helpers; Timetable UI migration is #72, multi-line cart sync is #73, Booking Details checkout is #74.

## Testing

- [x] `pnpm type-check`
- [x] `pnpm test`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge