### PR TITLE
feat(timetable): cart line subtotals via member preview-quote

### DIFF
--- a/src/api/services/facilityService.ts
+++ b/src/api/services/facilityService.ts
@@ -18,12 +18,24 @@ interface CreateBookingPayload {
   remark?: string;
 }
 
-interface PreviewQuotePayload {
+export interface PreviewQuoteLinePayload {
+  facilityId: string;
   startAt: string;
   endAt: string;
+}
+
+export interface PreviewQuotePayload {
   ministryId?: string | null;
   isMissionAligned?: boolean;
-  rooms: Array<{ facilityId: string }>;
+  lines: PreviewQuoteLinePayload[];
+}
+
+interface ApiPreviewQuoteRoomLine {
+  facilityId?: string;
+  facility_id?: string;
+  lineSubtotal?: string | number | null;
+  line_subtotal?: string | number | null;
+  currency?: string | null;
 }
 
 interface ApiPreviewQuote {
@@ -36,6 +48,14 @@ interface ApiPreviewQuote {
   quotedAmount?: string | number | null;
   quoted_amount?: string | number | null;
   currency?: string | null;
+  roomLines?: ApiPreviewQuoteRoomLine[];
+  room_lines?: ApiPreviewQuoteRoomLine[];
+}
+
+export interface MemberPreviewQuoteRoomLine {
+  facilityId: string;
+  lineSubtotal: string | number | null;
+  currency: string | null;
 }
 
 export interface MemberPreviewQuote {
@@ -44,6 +64,7 @@ export interface MemberPreviewQuote {
   surchargeAmount: string | number | null;
   quotedAmount: string | number | null;
   currency: string | null;
+  roomLines: MemberPreviewQuoteRoomLine[];
 }
 
 interface ApiBookingDetail {
@@ -90,12 +111,18 @@ class FacilityService {
       throw new Error(response.message || "Failed to load preview quote");
     }
     const data = response.data;
+    const rawRoomLines = data.roomLines ?? data.room_lines ?? [];
     return {
       subtotalAmount: data.subtotalAmount ?? data.subtotal_amount ?? null,
       discountAmount: data.discountAmount ?? data.discount_amount ?? null,
       surchargeAmount: data.surchargeAmount ?? data.surcharge_amount ?? null,
       quotedAmount: data.quotedAmount ?? data.quoted_amount ?? null,
       currency: data.currency ?? null,
+      roomLines: rawRoomLines.map((line) => ({
+        facilityId: String(line.facilityId ?? line.facility_id ?? ""),
+        lineSubtotal: line.lineSubtotal ?? line.line_subtotal ?? null,
+        currency: line.currency ?? data.currency ?? null,
+      })),
     };
   }
 

--- a/src/components/booking/BookingCartPanel.tsx
+++ b/src/components/booking/BookingCartPanel.tsx
@@ -1,4 +1,5 @@
 import { canReviewCart, type BookingLine, type RoomDay } from "@/utils/timetableRules";
+import { formatQuotedAmount } from "@/utils/paymentSummary";
 import { Button, cn } from "@efcnewlife/newlife-ui";
 import { useTranslation } from "react-i18next";
 import { MdPhoto } from "react-icons/md";
@@ -13,7 +14,7 @@ interface BookingCartPanelProps {
 }
 
 const BookingCartPanel = ({ lines, rooms, onReview, onRemove, onEdit, formatClock }: BookingCartPanelProps) => {
-  const { t } = useTranslation("booking");
+  const { t, i18n } = useTranslation("booking");
   const canReview = canReviewCart({ lines, pinned: null, whenSeed: null });
 
   const roomForLine = (facilityId: string): RoomDay | undefined => {
@@ -57,6 +58,9 @@ const BookingCartPanel = ({ lines, rooms, onReview, onRemove, onEdit, formatCloc
                     </p>
                     <p className="m-0 mt-1 text-xs font-medium text-on-surface-variant">
                       {formatClock(line.start)} – {formatClock(line.end)}
+                    </p>
+                    <p className="m-0 mt-1 text-xs font-semibold text-booking-primary">
+                      {formatQuotedAmount(line.lineSubtotal, line.currency, i18n.language)}
                     </p>
                   </div>
                 </div>

--- a/src/pages/booking-details/BookingDetailsPage.tsx
+++ b/src/pages/booking-details/BookingDetailsPage.tsx
@@ -1,4 +1,5 @@
 import facilityService from "@/api/services/facilityService";
+import { combineDateAndClock } from "@/utils/bookingDateTime";
 import { mapPaymentSummary, type PaymentSummaryLabels } from "@/utils/paymentSummary";
 import {
   parseBookingDetailsQuery,
@@ -14,11 +15,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
 
-const combineDateAndTime = (date: string, time: string): string => {
-  const clock = time === "24:00" ? "00:00" : time;
-  const day = time === "24:00" ? moment(date, "YYYY-MM-DD").add(1, "day") : moment(date, "YYYY-MM-DD");
-  return moment(`${day.format("YYYY-MM-DD")} ${clock}`, "YYYY-MM-DD HH:mm").toISOString();
-};
+const combineDateAndTime = combineDateAndClock;
 
 const formatClock = (clock: string, locale: string): string => {
   if (clock === "24:00") {
@@ -85,11 +82,13 @@ const BookingDetailsPage = () => {
     try {
       const { startAt, endAt } = bookingIntervalIso(query);
       const quote = await facilityService.previewQuote({
-        startAt,
-        endAt,
         ministryId: query.ministryId || null,
         isMissionAligned: Boolean(query.ministryId),
-        rooms: query.roomIds.map((facilityId) => ({ facilityId })),
+        lines: query.roomIds.map((facilityId) => ({
+          facilityId,
+          startAt,
+          endAt,
+        })),
       });
       setPaymentSummary(mapPaymentSummary(quote, i18nInstance.language));
     } catch {

--- a/src/pages/rooms/RoomFilterPage.tsx
+++ b/src/pages/rooms/RoomFilterPage.tsx
@@ -5,6 +5,7 @@ import ConfirmBookingTime from "@/components/booking/ConfirmBookingTime";
 import ImagePreview from "@/components/booking/ImagePreview";
 import type { MinistryItem } from "@/types/ministry";
 import { draftToCartState, parseBookingCartDraft, whenSeedFromSearch } from "@/utils/bookingCartDraft";
+import { applyCartLineQuote, fetchCartLineQuote } from "@/utils/cartLineQuote";
 import { canOpenImagePreview } from "@/utils/imagePreview";
 import {
   parseRoomsSearchQuery,
@@ -34,6 +35,7 @@ import {
   visibleRooms,
   type AvailableOverlayKind,
   type BookingInterval,
+  type BookingLine,
   type CapacityBand,
   type CellState,
   type HoverPreview,
@@ -140,6 +142,12 @@ const buildInitialCartState = (params: URLSearchParams, query: RoomsSearchQuery 
     return draftToCartState(draft, whenSeed);
   }
   return emptyCartState(whenSeed);
+};
+
+const QUOTE_KEY_SEP = "\0";
+
+const lineQuoteKey = (line: Pick<BookingLine, "sequence" | "facilityId" | "start" | "end">): string => {
+  return [line.sequence, line.facilityId, line.start, line.end].join(QUOTE_KEY_SEP);
 };
 
 const RoomFilterPage = () => {
@@ -280,6 +288,56 @@ const RoomFilterPage = () => {
     });
   }, [appliedDate, capacityBand, loading, rooms, view, whenSeed]);
 
+  const linesNeedingQuoteKey = cartState.lines
+    .filter((line) => line.lineSubtotal == null)
+    .map(lineQuoteKey)
+    .join("|");
+
+  useEffect(() => {
+    if (!appliedDate || !linesNeedingQuoteKey) {
+      return;
+    }
+    let cancelled = false;
+    const segments = linesNeedingQuoteKey.split("|").filter(Boolean);
+    const loadQuotes = async () => {
+      for (const segment of segments) {
+        const parts = segment.split(QUOTE_KEY_SEP);
+        if (parts.length !== 4) {
+          continue;
+        }
+        const sequence = Number.parseInt(parts[0], 10);
+        const facilityId = parts[1];
+        const start = parts[2];
+        const end = parts[3];
+        if (!Number.isFinite(sequence)) {
+          continue;
+        }
+        try {
+          const quote = await fetchCartLineQuote(appliedDate, { facilityId, start, end }, appliedMinistryId);
+          if (cancelled) {
+            return;
+          }
+          setCartState((current) => {
+            const existing = current.lines.find((item) => item.sequence === sequence);
+            if (!existing || existing.lineSubtotal != null) {
+              return current;
+            }
+            if (lineQuoteKey(existing) !== segment) {
+              return current;
+            }
+            return applyCartLineQuote(current, sequence, quote);
+          });
+        } catch {
+          // Leave em dash subtotal when quote fails.
+        }
+      }
+    };
+    void loadQuotes();
+    return () => {
+      cancelled = true;
+    };
+  }, [appliedDate, appliedMinistryId, linesNeedingQuoteKey]);
+
   const handleUpdateSearch = useCallback(() => {
     if (loading) {
       return;
@@ -368,10 +426,12 @@ const RoomFilterPage = () => {
     setEditingSequence(undefined);
   };
 
-  const handleConfirmBookingTime = (interval: BookingInterval) => {
-    if (!confirmRoom) {
+  const handleConfirmBookingTime = async (interval: BookingInterval) => {
+    if (!confirmRoom || !appliedDate) {
       return;
     }
+    let nextState: TimetableCartState | null = null;
+    let quotedSequence: number | undefined;
     if (editingSequence != null) {
       const updated = updateCartLine(cartState, editingSequence, {
         facilityId: confirmRoom.id,
@@ -379,7 +439,8 @@ const RoomFilterPage = () => {
         end: interval.end,
       });
       if (updated) {
-        setCartState(updated);
+        nextState = updated;
+        quotedSequence = editingSequence;
       }
     } else {
       const next = addCartLine(cartState, {
@@ -388,10 +449,25 @@ const RoomFilterPage = () => {
         end: interval.end,
       });
       if (next) {
-        setCartState(next);
+        nextState = next;
+        quotedSequence = next.lines[next.lines.length - 1]?.sequence;
       }
     }
     handleCancelConfirmBookingTime();
+    if (!nextState || quotedSequence == null) {
+      return;
+    }
+    setCartState(nextState);
+    const line = nextState.lines.find((item) => item.sequence === quotedSequence);
+    if (!line) {
+      return;
+    }
+    try {
+      const quote = await fetchCartLineQuote(appliedDate, line, appliedMinistryId);
+      setCartState((current) => applyCartLineQuote(current, quotedSequence!, quote));
+    } catch {
+      // Leave em dash subtotal when quote fails.
+    }
   };
 
   const pointerKindFromEvent = (event: { pointerType: string }): PointerKind => {

--- a/src/utils/bookingDateTime.ts
+++ b/src/utils/bookingDateTime.ts
@@ -1,0 +1,7 @@
+import moment from "moment";
+
+export const combineDateAndClock = (date: string, clock: string): string => {
+  const time = clock === "24:00" ? "00:00" : clock;
+  const day = clock === "24:00" ? moment(date, "YYYY-MM-DD").add(1, "day") : moment(date, "YYYY-MM-DD");
+  return moment(`${day.format("YYYY-MM-DD")} ${time}`, "YYYY-MM-DD HH:mm").toISOString();
+};

--- a/src/utils/cartLineQuote.test.ts
+++ b/src/utils/cartLineQuote.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { combineDateAndClock } from "./bookingDateTime";
+import { emptyCartState, setCartLineQuote, updateCartLine } from "./timetableRules";
+
+describe("combineDateAndClock", () => {
+  it("combines a calendar date and clock into ISO", () => {
+    const iso = combineDateAndClock("2026-09-02", "10:00");
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(new Date(iso).toString()).not.toBe("Invalid Date");
+  });
+
+  it("rolls midnight end times to the next calendar day", () => {
+    const iso = combineDateAndClock("2026-09-02", "24:00");
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(iso >= combineDateAndClock("2026-09-02", "23:00")).toBe(true);
+  });
+});
+
+describe("setCartLineQuote", () => {
+  it("stores subtotal and currency on one line", () => {
+    const state = {
+      ...emptyCartState(),
+      lines: [{ facilityId: "room-1", start: "10:00", end: "11:00", sequence: 1 }],
+    };
+    const next = setCartLineQuote(state, 1, "75.00", "CAD");
+    expect(next.lines[0]?.lineSubtotal).toBe("75.00");
+    expect(next.lines[0]?.currency).toBe("CAD");
+  });
+});
+
+describe("updateCartLine quote reset", () => {
+  it("clears line subtotal when the interval changes", () => {
+    const state = {
+      lines: [
+        { facilityId: "room-1", start: "10:00", end: "11:00", sequence: 1, lineSubtotal: "50.00", currency: "CAD" },
+      ],
+      pinned: null,
+      whenSeed: null,
+    };
+    const updated = updateCartLine(state, 1, { facilityId: "room-1", start: "10:00", end: "12:00" });
+    expect(updated?.lines[0]?.lineSubtotal).toBeUndefined();
+    expect(updated?.lines[0]?.currency).toBeUndefined();
+  });
+});

--- a/src/utils/cartLineQuote.ts
+++ b/src/utils/cartLineQuote.ts
@@ -1,0 +1,41 @@
+import type { PreviewQuoteLinePayload } from "@/api/services/facilityService";
+import facilityService from "@/api/services/facilityService";
+
+import { combineDateAndClock } from "./bookingDateTime";
+import { setCartLineQuote, type BookingLine, type TimetableCartState } from "./timetableRules";
+
+export { combineDateAndClock } from "./bookingDateTime";
+
+export const previewQuoteLinePayload = (
+  date: string,
+  line: Pick<BookingLine, "facilityId" | "start" | "end">
+): PreviewQuoteLinePayload => ({
+  facilityId: line.facilityId,
+  startAt: combineDateAndClock(date, line.start),
+  endAt: combineDateAndClock(date, line.end),
+});
+
+export const fetchCartLineQuote = async (
+  date: string,
+  line: Pick<BookingLine, "facilityId" | "start" | "end">,
+  ministryId?: string | null
+): Promise<{ lineSubtotal: string | number | null; currency: string | null }> => {
+  const quote = await facilityService.previewQuote({
+    ministryId: ministryId || null,
+    isMissionAligned: Boolean(ministryId),
+    lines: [previewQuoteLinePayload(date, line)],
+  });
+  const roomLine = quote.roomLines[0];
+  return {
+    lineSubtotal: roomLine?.lineSubtotal ?? null,
+    currency: roomLine?.currency ?? quote.currency,
+  };
+};
+
+export const applyCartLineQuote = (
+  state: TimetableCartState,
+  sequence: number,
+  quote: { lineSubtotal: string | number | null; currency: string | null }
+): TimetableCartState => {
+  return setCartLineQuote(state, sequence, quote.lineSubtotal, quote.currency);
+};

--- a/src/utils/paymentSummary.ts
+++ b/src/utils/paymentSummary.ts
@@ -17,7 +17,7 @@ export interface PaymentSummaryLabels {
 
 const EM_DASH = "—";
 
-const formatQuotedAmount = (
+export const formatQuotedAmount = (
   quotedAmount: string | number | null | undefined,
   currency: string | null | undefined,
   locale: string

--- a/src/utils/timetableRules.test.ts
+++ b/src/utils/timetableRules.test.ts
@@ -230,7 +230,7 @@ describe("cart mutations", () => {
   it("updates one line without creating a duplicate", () => {
     const state: TimetableCartState = {
       lines: [
-        { facilityId: "gym-id", start: "10:00", end: "11:00", sequence: 1 },
+        { facilityId: "gym-id", start: "10:00", end: "11:00", sequence: 1, lineSubtotal: "50.00", currency: "CAD" },
         { facilityId: "chapel-id", start: "10:00", end: "11:00", sequence: 2 },
       ],
       pinned: null,
@@ -242,6 +242,8 @@ describe("cart mutations", () => {
       start: "10:00",
       end: "12:00",
       sequence: 1,
+      lineSubtotal: undefined,
+      currency: undefined,
     });
     expect(hasDuplicateLine(updated!.lines, { facilityId: "chapel-id", start: "10:00", end: "11:00" })).toBe(true);
   });

--- a/src/utils/timetableRules.ts
+++ b/src/utils/timetableRules.ts
@@ -39,6 +39,8 @@ export type WhenSeedRange = TimeRange;
 export interface BookingLine extends TimeRange {
   facilityId: string;
   sequence: number;
+  lineSubtotal?: string | number | null;
+  currency?: string | null;
 }
 
 export interface PinnedInterval extends TimeRange {
@@ -273,6 +275,8 @@ export const updateCartLine = (
     start: line.start,
     end: line.end,
     sequence,
+    lineSubtotal: undefined,
+    currency: undefined,
   };
   return {
     ...state,
@@ -284,6 +288,18 @@ export const removeCartLine = (state: TimetableCartState, sequence: number): Tim
   return {
     ...state,
     lines: state.lines.filter((line) => line.sequence !== sequence),
+  };
+};
+
+export const setCartLineQuote = (
+  state: TimetableCartState,
+  sequence: number,
+  lineSubtotal: string | number | null,
+  currency: string | null
+): TimetableCartState => {
+  return {
+    ...state,
+    lines: state.lines.map((line) => (line.sequence === sequence ? { ...line, lineSubtotal, currency } : line)),
   };
 };
 


### PR DESCRIPTION
## Summary

Wire Timetable Booking cart lines to the member per-line preview-quote API: after each Confirm Booking Time, fetch a quote for that line and show the formatted subtotal in the cart panel. Draft cart lines restored without subtotals are backfilled via a quote effect; editing a line clears stale subtotals before re-quote. Booking Details preview-quote call is aligned with the new `lines[]` request shape (multi-line checkout UI remains #74).

Closes #73

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `facilityService.previewQuote` now sends per-line `lines[]` and maps `roomLines[].lineSubtotal`.
- Confirm handler awaits quote for the confirmed line; a secondary effect backfills quotes for draft-restored lines missing subtotals.
- Review Booking still navigates with the existing single-line query shape; multi-line Booking Details is #74.
- Requires backend member preview-quote per-line intervals (`efcnewlife/newlife-core-api#123`) on the API environment under test.

## Testing

- [x] `pnpm run type-check`
- [x] `pnpm test`
- [ ] Confirm a booking line on Timetable → cart row shows subtotal after quote loads
- [ ] Edit a line → subtotal refreshes for the new interval
- [ ] Remove a line → matching Timetable block shows ADD again
- [ ] Add up to three lines, including same room at different times; duplicate `(facilityId, start, end)` is rejected

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge